### PR TITLE
Rearranges mobile layout to have more screenspace

### DIFF
--- a/apis/src/components/atoms/mod.rs
+++ b/apis/src/components/atoms/mod.rs
@@ -17,4 +17,5 @@ pub mod status_indicator;
 pub mod svgs;
 pub mod target;
 pub mod title;
+pub mod toggle_controls;
 pub mod undo_button;

--- a/apis/src/components/atoms/toggle_controls.rs
+++ b/apis/src/components/atoms/toggle_controls.rs
@@ -1,0 +1,47 @@
+use crate::components::layouts::base_layout::ControlsSignal;
+use leptos::*;
+use leptos_icons::*;
+
+#[component]
+pub fn ToggleControls() -> impl IntoView {
+    let controls_signal = expect_context::<ControlsSignal>();
+    let toggle_controls = move |_| controls_signal.hidden.update(|b| *b = !*b);
+    let icon = move || {
+        if controls_signal.hidden.get() {
+            view! { <Icon icon=icondata::BiDownArrowSolid class="w-4 h-4"/> }
+        } else {
+            view! { <Icon icon=icondata::BiUpArrowSolid class="w-4 h-4"/> }
+        }
+    };
+    let title = move || {
+        if controls_signal.hidden.get() {
+            "Show controls"
+        } else {
+            "Hide Controls"
+        }
+    };
+
+    let button_color = move || {
+        if controls_signal.notify.get() && controls_signal.hidden.get() {
+            "bg-ladybug-red"
+        } else {
+            "bg-button-dawn dark:bg-button-twilight"
+        }
+    };
+
+    view! {
+        <button
+            title=title
+            on:click=toggle_controls
+            class=move || {
+                format!(
+                    "{} px-4 py-1 m-1 font-bold text-white rounded transition-transform duration-300 transform hover:bg-pillbug-teal active:scale-95",
+                    button_color(),
+                )
+            }
+        >
+
+            {icon}
+        </button>
+    }
+}

--- a/apis/src/components/molecules/analysis_and_download.rs
+++ b/apis/src/components/molecules/analysis_and_download.rs
@@ -6,21 +6,20 @@ use leptos_icons::*;
 #[component]
 pub fn AnalysisAndDownload() -> impl IntoView {
     let game_state = expect_context::<GameStateSignal>();
-    let is_finished = move || (game_state.signal)().is_finished();
     let analysis_setup = move |_| {
         let mut game_state = expect_context::<GameStateSignal>();
         game_state.do_analysis();
     };
 
     view! {
-        <Show when=is_finished>
-            <div class="flex items-center justify-center mt-1">
+        <Show when=game_state.is_finished()>
+            <div class="flex justify-center items-center mt-1">
                 <a
                     href="/analysis"
-                    class="bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal duration-300 text-white rounded m-1 place-self-center justify-self-end"
+                    class="justify-self-end place-self-center m-1 text-white rounded duration-300 bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal"
                     on:click=analysis_setup
                 >
-                    <Icon icon=icondata::TbMicroscope class="h-7 w-7 py-1"/>
+                    <Icon icon=icondata::TbMicroscope class="py-1 w-7 h-7"/>
                 </a>
                 <DownloadPgn/>
             </div>

--- a/apis/src/components/molecules/chat_and_controls.rs
+++ b/apis/src/components/molecules/chat_and_controls.rs
@@ -1,0 +1,27 @@
+use crate::{
+    components::{
+        atoms::toggle_controls::ToggleControls, layouts::base_layout::OrientationSignal,
+        organisms::dropdowns::ChatDropdown,
+    },
+    providers::{game_state::GameStateSignal, navigation_controller::NavigationControllerSignal},
+};
+use leptos::*;
+use shared_types::SimpleDestination;
+
+#[component]
+pub fn ChatAndControls() -> impl IntoView {
+    let gamestate = expect_context::<GameStateSignal>();
+    let navi = expect_context::<NavigationControllerSignal>();
+    let orientation_signal = expect_context::<OrientationSignal>();
+    let is_finished = gamestate.is_finished();
+    let in_mobile_game =
+        move || orientation_signal.orientation_vertical.get() && navi.signal.get().nanoid.is_some();
+    view! {
+        <Show when=in_mobile_game>
+            <Show when=move || !is_finished()>
+                <ToggleControls/>
+            </Show>
+            <ChatDropdown destination=SimpleDestination::Game/>
+        </Show>
+    }
+}

--- a/apis/src/components/molecules/control_buttons.rs
+++ b/apis/src/components/molecules/control_buttons.rs
@@ -12,7 +12,6 @@ use shared_types::{ChallengeDetails, ChallengeVisibility};
 #[component]
 pub fn ControlButtons() -> impl IntoView {
     let game_state = expect_context::<GameStateSignal>();
-    let is_finished = move || (game_state.signal)().is_finished();
     let auth_context = expect_context::<AuthContext>();
     let user = move || match untrack(auth_context.user) {
         Some(Ok(Some(user))) => Some(user),
@@ -171,7 +170,7 @@ pub fn ControlButtons() -> impl IntoView {
     view! {
         <div class="flex justify-around items-center mt-1 w-full grow shrink">
             <Show
-                when=is_finished
+                when=game_state.is_finished()
                 fallback=move || {
                     view! {
                         <div class="flex justify-around items-center grow shrink">

--- a/apis/src/components/molecules/hamburger.rs
+++ b/apis/src/components/molecules/hamburger.rs
@@ -1,6 +1,6 @@
 use leptos::html::Div;
 use leptos::*;
-use leptos_use::on_click_outside;
+use leptos_use::{on_click_outside_with_options, OnClickOutsideOptions};
 
 #[component]
 pub fn Hamburger<T: IntoView>(
@@ -11,20 +11,25 @@ pub fn Hamburger<T: IntoView>(
     dropdown_style: &'static str,
     content: T,
 ) -> impl IntoView {
-    let target = create_node_ref::<Div>();
+    let children_ref = create_node_ref::<Div>();
     create_effect(move |_| {
         if hamburger_show() {
-            let _ = on_click_outside(target, move |_| {
-                hamburger_show.update(|b| *b = false);
-            });
+            let _ = on_click_outside_with_options(
+                children_ref,
+                move |_| {
+                    hamburger_show.update(|b| *b = false);
+                },
+                OnClickOutsideOptions::default().ignore(["input", "#ignoreChat", "#ignoreButton"]),
+            );
         }
     });
 
     let children = store_value(children);
 
     view! {
-        <div node_ref=target class=format!("inline-block {extend_tw_classes}")>
+        <div class=format!("inline-block {extend_tw_classes}")>
             <button
+                id="ignoreButton"
                 on:click=move |_| hamburger_show.update(|b| *b = !*b)
 
                 class=button_style
@@ -32,7 +37,9 @@ pub fn Hamburger<T: IntoView>(
                 {content}
             </button>
             <Show when=hamburger_show>
-                <div class=dropdown_style>{children()}</div>
+                <div ref=children_ref class=dropdown_style>
+                    {children()}
+                </div>
             </Show>
         </div>
     }

--- a/apis/src/components/molecules/mod.rs
+++ b/apis/src/components/molecules/mod.rs
@@ -3,6 +3,7 @@ pub mod analysis_and_download;
 pub mod banner;
 pub mod board_pieces;
 pub mod challenge_row;
+pub mod chat_and_controls;
 pub mod control_buttons;
 pub mod game_info;
 pub mod game_row;

--- a/apis/src/components/molecules/user_with_rating.rs
+++ b/apis/src/components/molecules/user_with_rating.rs
@@ -29,7 +29,6 @@ pub fn UserWithRating(
             .game_response
             .map(|g| g.black_player),
     };
-    let is_finished = move || (game_state.signal)().is_finished();
     let speed = move || {
         game_state
             .signal
@@ -64,7 +63,7 @@ pub fn UserWithRating(
                 }
             }}
             <Show
-                when=is_finished
+                when=game_state.is_finished()
                 fallback=move || {
                     view! { <div class=format!("{text_color}")>{rating}</div> }
                 }

--- a/apis/src/components/organisms/chat.rs
+++ b/apis/src/components/organisms/chat.rs
@@ -20,12 +20,12 @@ pub fn Message(message: ChatMessage) -> impl IntoView {
 
     view! {
         <div class="flex flex-col items-start mb-1 w-full">
-            <div class="flex px-2 gap-1">
+            <div class="flex gap-1 px-2">
                 <div class="font-bold">{message.username}</div>
                 {user_local_time}
                 {turn}
             </div>
-            <div class="px-2 max-w-fit break-words">{message.message}</div>
+            <div class="px-2 break-words max-w-fit">{message.message}</div>
         </div>
     }
 }
@@ -159,8 +159,8 @@ pub fn ChatWindow(
             .unwrap_or_default(),
     };
     view! {
-        <div class="flex flex-col h-full">
-            <div ref=div class="overflow-y-auto h-full">
+        <div id="ignoreChat" class="flex flex-col max-w-full h-full min-h-full">
+            <div ref=div class="overflow-y-auto overflow-x-hidden w-full h-full">
                 <For each=messages key=|message| message.timestamp let:message>
                     <Message message=message/>
                 </For>

--- a/apis/src/components/organisms/darkmode_toggle.rs
+++ b/apis/src/components/organisms/darkmode_toggle.rs
@@ -3,14 +3,16 @@ use leptos::*;
 use leptos_router::ActionForm;
 
 #[component]
-pub fn DarkModeToggle() -> impl IntoView {
+pub fn DarkModeToggle(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
     let color_scheme = expect_context::<ColorScheme>();
-
     view! {
         <ActionForm
             action=color_scheme.action
-            class="inline-flex justify-center items-center max-h-6 text-base font-medium rounded-md border border-transparent shadow md:max-h-7 dark:bg-orange-twilight bg-gray-950"
+            class=format!(
+                "inline-flex justify-center items-center m-1 rounded dark:bg-orange-twilight bg-gray-950 {extend_tw_classes}",
+            )
         >
+
             <input
                 type="hidden"
                 name="prefers_dark"

--- a/apis/src/components/organisms/dropdowns.rs
+++ b/apis/src/components/organisms/dropdowns.rs
@@ -1,6 +1,9 @@
-use crate::components::layouts::base_layout::{COMMON_LINK_STYLE, DROPDOWN_BUTTON_STYLE};
+use crate::components::layouts::base_layout::{
+    OrientationSignal, COMMON_LINK_STYLE, DROPDOWN_BUTTON_STYLE,
+};
 use crate::components::molecules::{hamburger::Hamburger, ping::Ping};
 use crate::components::organisms::chat::ChatWindow;
+use crate::components::organisms::darkmode_toggle::DarkModeToggle;
 use crate::components::organisms::header::set_redirect;
 use crate::components::organisms::logout::Logout;
 use crate::providers::chat::Chat;
@@ -45,6 +48,7 @@ pub fn UserDropdown(username: String) -> impl IntoView {
             >
                 Config
             </a>
+            <DarkModeToggle/>
             <Logout on:submit=move |_| onclick_close()/>
             <Ping/>
         </Hamburger>
@@ -177,15 +181,16 @@ pub fn CommunityDropdown() -> impl IntoView {
 #[component]
 pub fn ChatDropdown(destination: SimpleDestination) -> impl IntoView {
     let chat = expect_context::<Chat>();
-    let hamburger_show = expect_context::<RwSignal<bool>>();
-    let chat_style = "flex flex-col absolute bg-even-light dark:bg-gray-950 border border-gray-300 p-2 right-0 w-full h-[75%] z-50";
+    let destination = StoredValue::new(destination);
+    let hamburger_show = expect_context::<OrientationSignal>().chat_dropdown_open;
+    let chat_style = "absolute z-50 flex-col w-full h-[80dvh] max-w-screen bg-even-light dark:bg-gray-950 border border-gray-300 rounded-md left-0 p-2";
     let button_color = move || {
         if hamburger_show() {
-            "bg-button-dawn dark:bg-button-twilight"
+            "bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal"
         } else if chat.has_messages() {
             "bg-ladybug-red"
         } else {
-            "bg-button-dawn dark:bg-button-twilight"
+            "bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal"
         }
     };
 
@@ -199,16 +204,15 @@ pub fn ChatDropdown(destination: SimpleDestination) -> impl IntoView {
             hamburger_show=hamburger_show
             button_style=Signal::derive(move || {
                 format!(
-                    "{} h-7 m-1 grow hover:bg-pillbug-teal transform transition-transform duration-300 active:scale-95 text-white font-bold py-1 px-2 rounded flex-shrink-0",
+                    "{} transform transition-transform duration-300 active:scale-95 text-white font-bold py-1 m-1 px-4 rounded",
                     button_color(),
                 )
             })
 
-            extend_tw_classes="mt-1"
             dropdown_style=chat_style
-            content="Chat"
+            content=view! { <Icon icon=icondata::BiChatRegular class="w-4 h-4"/> }
         >
-            <ChatWindow destination=destination.clone()/>
+            <ChatWindow destination=destination()/>
         </Hamburger>
     }
 }

--- a/apis/src/components/organisms/header.rs
+++ b/apis/src/components/organisms/header.rs
@@ -1,4 +1,5 @@
 use crate::components::atoms::next_game_button::NextGameButton;
+use crate::components::molecules::chat_and_controls::ChatAndControls;
 use crate::components::organisms::{
     darkmode_toggle::DarkModeToggle,
     dropdowns::{CommunityDropdown, MobileDropdown, UserDropdown},
@@ -12,13 +13,11 @@ use shared_types::TimeMode;
 pub struct Redirect(pub RwSignal<String>);
 
 #[component]
-pub fn Header(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
+pub fn Header() -> impl IntoView {
     let auth_context = expect_context::<AuthContext>();
 
     view! {
-        <header class=format!(
-            "w-full fixed top-0 flex justify-between items-center bg-gray-300 dark:bg-header-twilight z-50 max-w-[100vw] select-none {extend_tw_classes}",
-        )>
+        <header class="w-full fixed top-0 flex justify-between items-center bg-gray-300 dark:bg-header-twilight z-50 max-w-[100vw] select-none">
             <Transition fallback=|| {
                 view! {
                     <div class="flex gap-1 items-center lg:ml-10">
@@ -46,7 +45,8 @@ pub fn Header(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoVie
                         </div>
                     </div>
                     <div class="flex items-center lg:mr-10">
-                        <DarkModeToggle/>
+                        <ChatAndControls/>
+                        <DarkModeToggle extend_tw_classes="max-h-6 sm:max-h-7"/>
                         <a
                             class="px-4 py-1 m-1 font-bold text-white rounded transition-transform duration-300 transform bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal active:scale-95"
                             href="/login"
@@ -93,7 +93,8 @@ pub fn Header(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoVie
                             fallback=|| {
                                 view! {
                                     <div class="flex items-center lg:mr-10">
-                                        <DarkModeToggle/>
+                                        <ChatAndControls/>
+                                        <DarkModeToggle extend_tw_classes="max-h-6 sm:max-h-7"/>
                                         <a
                                             class="px-4 py-1 m-1 font-bold text-white rounded transition-transform duration-300 transform bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal active:scale-95"
                                             href="/login"
@@ -113,7 +114,7 @@ pub fn Header(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoVie
                                 <NextGameButton time_mode=store_value(TimeMode::Untimed)/>
                             </div>
                             <div class="flex items-center lg:mr-10">
-                                <DarkModeToggle/>
+                                <ChatAndControls/>
                                 <UserDropdown username=user().expect("User is some").username/>
                             </div>
                         </Show>

--- a/apis/src/pages/analysis.rs
+++ b/apis/src/pages/analysis.rs
@@ -4,6 +4,7 @@ use crate::{
             history_button::{HistoryButton, HistoryNavigation},
             undo_button::UndoButton,
         },
+        layouts::base_layout::OrientationSignal,
         organisms::{
             board::Board,
             reserve::{Alignment, Reserve},
@@ -15,7 +16,6 @@ use crate::{
 };
 use hive_lib::Color;
 use leptos::*;
-use leptos_use::use_media_query;
 
 #[derive(Clone)]
 pub struct InAnalysis(pub RwSignal<bool>);
@@ -24,7 +24,7 @@ pub struct InAnalysis(pub RwSignal<bool>);
 pub fn Analysis(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
     provide_context(TargetStack(RwSignal::new(None)));
     provide_context(InAnalysis(RwSignal::new(true)));
-    let is_tall = use_media_query("(min-height: 100vw)");
+    let is_tall = expect_context::<OrientationSignal>().is_tall;
     let parent_container_style = move || {
         if is_tall() {
             "flex flex-col"

--- a/apis/src/providers/chat.rs
+++ b/apis/src/providers/chat.rs
@@ -44,7 +44,7 @@ impl Chat {
     pub fn has_messages(&self) -> bool {
         let navi = expect_context::<NavigationControllerSignal>();
 
-        if let Some(nanoid) = navi.signal.get_untracked().nanoid {
+        if let Some(nanoid) = navi.signal.get().nanoid {
             self.games_public_new_messages
                 .get()
                 .get(&nanoid)

--- a/apis/src/providers/game_state.rs
+++ b/apis/src/providers/game_state.rs
@@ -188,6 +188,19 @@ impl GameStateSignal {
         self.signal
             .update(|s| s.game_response = Some(game_response))
     }
+
+    pub fn is_finished(&self) -> Memo<bool> {
+        let game_status_finished = create_read_slice(self.signal, |game_state| {
+            matches!(game_state.state.game_status, GameStatus::Finished(_))
+        });
+        let game_response_finished = create_read_slice(self.signal, |game_state| {
+            game_state
+                .game_response
+                .as_ref()
+                .is_some_and(|gr| gr.finished)
+        });
+        Memo::new(move |_| game_status_finished() || game_response_finished())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -314,11 +327,6 @@ impl GameState {
                 black_id.is_some_and(|black| black == user.id)
             }
         })
-    }
-
-    pub fn is_finished(&self) -> bool {
-        matches!(self.state.game_status, GameStatus::Finished(_))
-            || self.game_response.as_ref().is_some_and(|gr| gr.finished)
     }
 
     pub fn move_active(&mut self) {

--- a/apis/src/providers/websocket/game/reaction/control.rs
+++ b/apis/src/providers/websocket/game/reaction/control.rs
@@ -31,7 +31,6 @@ pub fn handle_control(game_control: GameControl, gar: GameActionResponse) {
                             gar.username
                         )));
                     });
-                    // TODO: Once we have notifications tell the user the game was aborted
                     let navigate = leptos_router::use_navigate();
                     navigate("/", Default::default());
                 }


### PR DESCRIPTION
Gains screen space on mobile for ongoing games by:
- Moving mobile chat to header.
- Hiding game control buttons on mobile for ongoing games and adds a button to show them.
- Assorted css changes to accommodate the reorganization

Bonus: experiments with using slices for accessing part of the gamestate signal.