### PR TITLE
Avoids opening multiple pools per request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "cookie 0.18.1",
  "db",
  "diesel",
+ "diesel-async",
  "diesel_migrations",
  "hive",
  "http 1.1.0",

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -22,6 +22,7 @@ cookie = { workspace = true }
 db = { path = "../db", optional = true  }
 diesel = { workspace = true, optional = true }
 diesel_migrations = { workspace = true, optional = true }
+diesel-async = { workspace = true, optional = true }
 hive = { path = "../engine" }
 shared_types = { path = "../shared_types" }
 http = { workspace = true }
@@ -64,6 +65,7 @@ ssr = [
   "dep:db",
   "dep:diesel",
   "dep:diesel_migrations",
+  "dep:diesel-async",
   "dep:leptos_actix",
   "leptos/ssr",
   "leptos-use/ssr",

--- a/apis/src/functions/accounts/delete.rs
+++ b/apis/src/functions/accounts/delete.rs
@@ -4,10 +4,12 @@ use leptos::*;
 pub async fn delete_account() -> Result<(), ServerFnError> {
     use crate::functions::auth::{identity::uuid, logout::logout};
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     use db_lib::models::User;
-    let pool = pool()?;
     let uuid = uuid()?;
-    let user = User::find_by_uuid(&uuid, &pool).await?;
-    user.delete(&pool).await?;
+    let pool = pool()?;
+    let mut conn = get_conn(&pool).await?;
+    let user = User::find_by_uuid(&uuid, &mut conn).await?;
+    user.delete(&mut conn).await?;
     logout().await
 }

--- a/apis/src/functions/accounts/get.rs
+++ b/apis/src/functions/accounts/get.rs
@@ -1,15 +1,18 @@
-use crate::functions::accounts::account_response::AccountResponse;
+use crate::responses::AccountResponse;
 use leptos::*;
 
 #[server]
 pub async fn get_account() -> Result<Option<AccountResponse>, ServerFnError> {
     use crate::functions::auth::identity::uuid;
     use crate::functions::db::pool;
+    use db_lib::get_conn;
 
     let uuid = match uuid() {
         Ok(uuid) => uuid,
         Err(_) => return Ok(None),
     };
-    let account_response = AccountResponse::from_uuid(&uuid, &pool()?).await?;
+    let pool = pool()?;
+    let mut conn = get_conn(&pool).await?;
+    let account_response = AccountResponse::from_uuid(&uuid, &mut conn).await?;
     Ok(Some(account_response))
 }

--- a/apis/src/functions/accounts/mod.rs
+++ b/apis/src/functions/accounts/mod.rs
@@ -1,4 +1,3 @@
-pub mod account_response;
 pub mod delete;
 pub mod edit;
 pub mod get;

--- a/apis/src/functions/challenges/get.rs
+++ b/apis/src/functions/challenges/get.rs
@@ -5,10 +5,12 @@ use uuid::Uuid;
 #[server]
 pub async fn get_challenge_by_uuid(id: Uuid) -> Result<ChallengeResponse, ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     use db_lib::models::Challenge;
     let pool = pool()?;
-    let challenge = Challenge::find_by_uuid(&id, &pool).await?;
-    ChallengeResponse::from_model(&challenge, &pool)
+    let mut conn = get_conn(&pool).await?;
+    let challenge = Challenge::find_by_uuid(&id, &mut conn).await?;
+    ChallengeResponse::from_model(&challenge, &mut conn)
         .await
         .map_err(ServerFnError::new)
 }
@@ -16,10 +18,12 @@ pub async fn get_challenge_by_uuid(id: Uuid) -> Result<ChallengeResponse, Server
 #[server]
 pub async fn get_challenge_by_nanoid(nanoid: String) -> Result<ChallengeResponse, ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     use db_lib::models::Challenge;
     let pool = pool()?;
-    let challenge = Challenge::find_by_nanoid(&nanoid, &pool).await?;
-    ChallengeResponse::from_model(&challenge, &pool)
+    let mut conn = get_conn(&pool).await?;
+    let challenge = Challenge::find_by_nanoid(&nanoid, &mut conn).await?;
+    ChallengeResponse::from_model(&challenge, &mut conn)
         .await
         .map_err(ServerFnError::new)
 }

--- a/apis/src/functions/games/get.rs
+++ b/apis/src/functions/games/get.rs
@@ -5,8 +5,10 @@ use uuid::Uuid;
 #[server]
 pub async fn get_game_from_uuid(game_id: Uuid) -> Result<GameResponse, ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     let pool = pool()?;
-    GameResponse::new_from_uuid(game_id, &pool)
+    let mut conn = get_conn(&pool).await?;
+    GameResponse::new_from_uuid(game_id, &mut conn)
         .await
         .map_err(ServerFnError::new)
 }
@@ -14,8 +16,10 @@ pub async fn get_game_from_uuid(game_id: Uuid) -> Result<GameResponse, ServerFnE
 #[server]
 pub async fn get_game_from_nanoid(nanoid: String) -> Result<GameResponse, ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     let pool = pool()?;
-    GameResponse::new_from_nanoid(&nanoid, &pool)
+    let mut conn = get_conn(&pool).await?;
+    GameResponse::new_from_nanoid(&nanoid, &mut conn)
         .await
         .map_err(ServerFnError::new)
 }

--- a/apis/src/functions/users/get.rs
+++ b/apis/src/functions/users/get.rs
@@ -7,8 +7,10 @@ use uuid::Uuid;
 #[server]
 pub async fn get_user_by_uuid(uuid: Uuid) -> Result<UserResponse, ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     let pool = pool()?;
-    UserResponse::from_uuid(&uuid, &pool)
+    let mut conn = get_conn(&pool).await?;
+    UserResponse::from_uuid(&uuid, &mut conn)
         .await
         .map_err(ServerFnError::new)
 }
@@ -16,8 +18,10 @@ pub async fn get_user_by_uuid(uuid: Uuid) -> Result<UserResponse, ServerFnError>
 #[server]
 pub async fn get_user_by_username(username: String) -> Result<UserResponse, ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     let pool = pool()?;
-    UserResponse::from_username(&username, &pool)
+    let mut conn = get_conn(&pool).await?;
+    UserResponse::from_username(&username, &mut conn)
         .await
         .map_err(ServerFnError::new)
 }
@@ -25,20 +29,24 @@ pub async fn get_user_by_username(username: String) -> Result<UserResponse, Serv
 #[server]
 pub async fn username_taken(username: String) -> Result<bool, ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     use db_lib::models::User;
     let pool = pool()?;
-    Ok(User::username_exists(&username, &pool).await?)
+    let mut conn = get_conn(&pool).await?;
+    Ok(User::username_exists(&username, &mut conn).await?)
 }
 
 #[server]
 pub async fn get_ongoing_games(username: String) -> Result<Vec<GameResponse>, ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     use db_lib::models::Game;
     let pool = pool()?;
-    let games: Vec<Game> = Game::get_ongoing_games_for_username(&username, &pool).await?;
+    let mut conn = get_conn(&pool).await?;
+    let games: Vec<Game> = Game::get_ongoing_games_for_username(&username, &mut conn).await?;
     let mut results: Vec<GameResponse> = Vec::new();
     for game in games.iter() {
-        if let Ok(game_response) = GameResponse::new_from_db(game, &pool).await {
+        if let Ok(game_response) = GameResponse::new_from_db(game, &mut conn).await {
             results.push(game_response);
         }
     }
@@ -53,15 +61,22 @@ pub async fn get_finished_games_in_batches(
     amount: i64,
 ) -> Result<(Vec<GameResponse>, bool), ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     use db_lib::models::Game;
     let pool = pool()?;
-    let games: Vec<Game> =
-        Game::get_x_finished_games_for_username(&username, &pool, last_timestamp, last_id, amount)
-            .await?;
+    let mut conn = get_conn(&pool).await?;
+    let games: Vec<Game> = Game::get_x_finished_games_for_username(
+        &username,
+        &mut conn,
+        last_timestamp,
+        last_id,
+        amount,
+    )
+    .await?;
     let mut results: Vec<GameResponse> = Vec::new();
     let got_amount = games.len() as i64 == amount;
     for game in games.iter() {
-        if let Ok(game_response) = GameResponse::new_from_db(game, &pool).await {
+        if let Ok(game_response) = GameResponse::new_from_db(game, &mut conn).await {
             results.push(game_response);
         }
     }
@@ -74,13 +89,15 @@ pub async fn get_top_users(
     limit: i64,
 ) -> Result<Vec<UserResponse>, ServerFnError> {
     use crate::functions::db::pool;
+    use db_lib::get_conn;
     use db_lib::models::{Rating, User};
     let pool = pool()?;
-    let top_users: Vec<(User, Rating)> = User::get_top_users(&game_speed, limit, &pool).await?;
+    let mut conn = get_conn(&pool).await?;
+    let top_users: Vec<(User, Rating)> = User::get_top_users(&game_speed, limit, &mut conn).await?;
     let mut results: Vec<UserResponse> = Vec::new();
     for (user, _rating) in top_users.iter() {
         results.push(
-            UserResponse::from_user(user, &pool)
+            UserResponse::from_user(user, &mut conn)
                 .await
                 .map_err(ServerFnError::new)?,
         )

--- a/apis/src/providers/auth_context.rs
+++ b/apis/src/providers/auth_context.rs
@@ -1,7 +1,7 @@
-use crate::functions::accounts::account_response::AccountResponse;
 use crate::functions::accounts::get::get_account;
 use crate::functions::auth::{login::Login, logout::Logout, register::Register};
 use crate::providers::websocket::WebsocketContext;
+use crate::responses::AccountResponse;
 use leptos::*;
 
 #[derive(Clone)]

--- a/apis/src/responses/account.rs
+++ b/apis/src/responses/account.rs
@@ -1,3 +1,4 @@
+use crate::responses::UserResponse;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -10,18 +11,16 @@ pub struct AccountResponse {
 }
 
 use cfg_if::cfg_if;
-
-use crate::responses::UserResponse;
 cfg_if! { if #[cfg(feature = "ssr")] {
 use db_lib::{
     models::User,
-    DbPool,
+    DbConn,
 };
 use leptos::*;
 impl AccountResponse {
-    pub async fn from_uuid(id: &Uuid, pool: &DbPool) -> Result<Self, ServerFnError> {
-        let user = User::find_by_uuid(id, pool).await?;
-        let response = UserResponse::from_user(&user, pool).await.map_err(ServerFnError::new)?;
+    pub async fn from_uuid(id: &Uuid, conn: &mut DbConn<'_>) -> Result<Self, ServerFnError> {
+        let user = User::find_by_uuid(id, conn).await?;
+        let response = UserResponse::from_user(&user, conn).await.map_err(ServerFnError::new)?;
         Ok(Self {
             username: user.username,
             email: user.email,

--- a/apis/src/responses/mod.rs
+++ b/apis/src/responses/mod.rs
@@ -1,7 +1,9 @@
+mod account;
 mod challenge;
 mod game;
 mod rating;
 mod user;
+pub use account::AccountResponse;
 pub use challenge::{create_challenge_handler, ChallengeResponse};
 pub use game::GameResponse;
 pub use rating::RatingResponse;

--- a/apis/src/responses/rating.rs
+++ b/apis/src/responses/rating.rs
@@ -17,25 +17,25 @@ use cfg_if::cfg_if;
 cfg_if! { if #[cfg(feature = "ssr")] {
 use db_lib::{
     models::{Rating, User},
-    DbPool,
+    DbConn,
 };
 use std::str::FromStr;
 use uuid::Uuid;
 use anyhow::Result;
 impl RatingResponse {
-    pub async fn from_uuid(id: &Uuid, game_speed: &GameSpeed, pool: &DbPool) -> Result<Self> {
-        let rating = Rating::for_uuid(id, game_speed, pool).await?;
+    pub async fn from_uuid(id: &Uuid, game_speed: &GameSpeed, conn: &mut DbConn<'_>) -> Result<Self> {
+        let rating = Rating::for_uuid(id, game_speed, conn).await?;
         Ok(Self::from_rating(&rating))
     }
 
-    pub async fn from_user(user: &User, game_speed: &GameSpeed, pool: &DbPool) -> Result<Self> {
-        let rating = Rating::for_uuid(&user.id, game_speed, pool).await?;
+    pub async fn from_user(user: &User, game_speed: &GameSpeed, conn: &mut DbConn<'_>) -> Result<Self> {
+        let rating = Rating::for_uuid(&user.id, game_speed, conn).await?;
         Ok(Self::from_rating(&rating))
     }
 
-    pub async fn from_username(username: &str, game_speed: &GameSpeed, pool: &DbPool) -> Result<Self> {
-        let user = User::find_by_username(username, pool).await?;
-        let rating = Rating::for_uuid(&user.id, game_speed, pool).await?;
+    pub async fn from_username(username: &str, game_speed: &GameSpeed, conn: &mut DbConn<'_>) -> Result<Self> {
+        let user = User::find_by_username(username, conn).await?;
+        let rating = Rating::for_uuid(&user.id, game_speed, conn).await?;
         Ok(Self::from_rating(&rating))
     }
 

--- a/apis/src/responses/user.rs
+++ b/apis/src/responses/user.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use shared_types::GameSpeed;
 use std::collections::HashMap;
+use super::rating::RatingResponse;
 use uuid::Uuid;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -78,39 +79,37 @@ impl UserResponse {
     }
 }
 
-use cfg_if::cfg_if;
-
-use super::rating::RatingResponse;
-cfg_if! { if #[cfg(feature = "ssr")] {
+cfg_if::cfg_if!{ if #[cfg(feature = "ssr")] {
 use db_lib::{
     models::User,
-    DbPool,
+    DbConn,
 };
 use anyhow::Result;
 impl UserResponse {
-    pub async fn from_uuid(id: &Uuid, pool: &DbPool) -> Result<Self> {
-        let user = User::find_by_uuid(id, pool).await?;
-        Self::from_user(&user, pool).await
+    pub async fn from_uuid(id: &Uuid, conn: &mut DbConn<'_>) -> Result<Self> {
+        let user = User::find_by_uuid(id, conn).await?;
+        Self::from_user(&user, conn).await
     }
 
-    pub async fn from_username(username: &str, pool: &DbPool) -> Result<Self> {
-        let user = User::find_by_username(username, pool).await?;
-        Self::from_user(&user, pool).await
+    pub async fn from_username(username: &str, conn: &mut DbConn<'_>) -> Result<Self> {
+        let user = User::find_by_username(username, conn).await?;
+        Self::from_user(&user, conn).await
     }
 
-    pub async fn from_user(user: &User, pool: &DbPool) -> Result<Self> {
+    pub async fn from_user(user: &User, conn: &mut DbConn<'_>) -> Result<Self> {
         let mut ratings = HashMap::new();
         for game_speed in GameSpeed::all_rated().into_iter() {
-            let rating = RatingResponse::from_user(user, &game_speed, pool).await?;
+            let rating = RatingResponse::from_user(user, &game_speed, conn).await?;
             ratings.insert(game_speed, rating);
         }
-        Ok(Self {
+        let response = UserResponse {
             username: user.username.clone(),
             uid: user.id,
             patreon: user.patreon,
             admin: user.admin,
             ratings,
-        })
+        };
+        Ok(response)
     }
 }
 }}

--- a/apis/src/websockets/api/challenges/delete.rs
+++ b/apis/src/websockets/api/challenges/delete.rs
@@ -4,6 +4,7 @@ use crate::{
     responses::ChallengeResponse,
 };
 use anyhow::Result;
+use db_lib::get_conn;
 use db_lib::{models::Challenge, DbPool};
 use shared_types::{ChallengeError, ChallengeVisibility};
 use uuid::Uuid;
@@ -24,12 +25,13 @@ impl DeleteHandler {
     }
 
     pub async fn handle(&self) -> Result<Vec<InternalServerMessage>> {
-        let challenge = Challenge::find_by_nanoid(&self.nanoid, &self.pool).await?;
+        let mut conn = get_conn(&self.pool).await?;
+        let challenge = Challenge::find_by_nanoid(&self.nanoid, &mut conn).await?;
         if challenge.challenger_id != self.user_id && challenge.opponent_id != Some(self.user_id) {
             return Err(ChallengeError::NotUserChallenge.into());
         }
-        let challenge_response = ChallengeResponse::from_model(&challenge, &self.pool).await?;
-        challenge.delete(&self.pool).await?;
+        let challenge_response = ChallengeResponse::from_model(&challenge, &mut conn).await?;
+        challenge.delete(&mut conn).await?;
         let mut messages = Vec::new();
         match challenge_response.visibility {
             ChallengeVisibility::Public => {

--- a/apis/src/websockets/api/challenges/get.rs
+++ b/apis/src/websockets/api/challenges/get.rs
@@ -4,6 +4,7 @@ use crate::{
     responses::ChallengeResponse,
 };
 use anyhow::Result;
+use db_lib::get_conn;
 use db_lib::{models::Challenge, DbPool};
 use shared_types::{ChallengeError, ChallengeVisibility};
 use uuid::Uuid;
@@ -24,8 +25,9 @@ impl GetHandler {
     }
 
     pub async fn handle(&self) -> Result<Vec<InternalServerMessage>> {
-        let challenge = Challenge::find_by_nanoid(&self.nanoid, &self.pool).await?;
-        let challenge_response = ChallengeResponse::from_model(&challenge, &self.pool).await?;
+        let mut conn = get_conn(&self.pool).await?;
+        let challenge = Challenge::find_by_nanoid(&self.nanoid, &mut conn).await?;
+        let challenge_response = ChallengeResponse::from_model(&challenge, &mut conn).await?;
         if challenge.visibility == ChallengeVisibility::Public.to_string()
             || challenge.challenger_id == self.user_id
             || challenge.opponent_id == Some(self.user_id)

--- a/apis/src/websockets/api/challenges/get_public.rs
+++ b/apis/src/websockets/api/challenges/get_public.rs
@@ -1,10 +1,10 @@
-use crate::websockets::internal_server_message::{InternalServerMessage, MessageDestination};
 use crate::{
     common::{ChallengeUpdate, ServerMessage},
     responses::ChallengeResponse,
+    websockets::internal_server_message::{InternalServerMessage, MessageDestination},
 };
 use anyhow::Result;
-use db_lib::{models::Challenge, DbPool};
+use db_lib::{get_conn, models::Challenge, DbPool};
 use uuid::Uuid;
 
 pub struct GetPublicHandler {
@@ -21,9 +21,10 @@ impl GetPublicHandler {
     }
 
     pub async fn handle(&self) -> Result<Vec<InternalServerMessage>> {
+        let mut conn = get_conn(&self.pool).await?;
         let mut responses = Vec::new();
-        for challenge in Challenge::get_public(&self.pool).await? {
-            responses.push(ChallengeResponse::from_model(&challenge, &self.pool).await?);
+        for challenge in Challenge::get_public(&mut conn).await? {
+            responses.push(ChallengeResponse::from_model(&challenge, &mut conn).await?);
         }
         Ok(vec![InternalServerMessage {
             destination: MessageDestination::User(self.user_id),

--- a/apis/src/websockets/api/game/control_handler.rs
+++ b/apis/src/websockets/api/game/control_handler.rs
@@ -7,9 +7,12 @@ use crate::{
 };
 use anyhow::Result;
 use db_lib::{
+    get_conn,
     models::{Game, User},
-    DbPool,
+    DbConn, DbPool,
 };
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::AsyncConnection;
 use hive_lib::{GameControl, GameError};
 use shared_types::TimeMode;
 use uuid::Uuid;
@@ -25,13 +28,13 @@ pub struct GameControlHandler {
 impl GameControlHandler {
     pub fn new(
         control: &GameControl,
-        game: Game,
+        game: &Game,
         username: &str,
         user_id: Uuid,
         pool: &DbPool,
     ) -> Self {
         Self {
-            game,
+            game: game.to_owned(),
             user_id,
             username: username.to_owned(),
             pool: pool.clone(),
@@ -40,6 +43,7 @@ impl GameControlHandler {
     }
 
     pub async fn handle(&self) -> Result<Vec<InternalServerMessage>> {
+        let mut conn = get_conn(&self.pool).await?;
         let mut messages = Vec::new();
         // the GC can be played this turn
         self.ensure_gc_allowed_for_turn()?;
@@ -47,8 +51,14 @@ impl GameControlHandler {
         self.ensure_gc_color()?;
         // the gc hasn't been sent previously
         self.ensure_fresh_game_control()?;
-        let game = self.match_control().await?;
-        let game_response = GameResponse::new_from_db(&game, &self.pool).await?;
+
+        let game = conn
+            .transaction::<_, anyhow::Error, _>(move |tc| {
+                async move { self.match_control(tc).await }.scope_boxed()
+            })
+            .await?;
+        let game_response = GameResponse::new_from_db(&game, &mut conn).await?;
+
         messages.push(InternalServerMessage {
             destination: MessageDestination::Game(self.game.nanoid.clone()),
             message: ServerMessage::Game(Box::new(GameUpdate::Reaction(GameActionResponse {
@@ -61,13 +71,11 @@ impl GameControlHandler {
         });
         match self.control {
             GameControl::DrawOffer(_) | GameControl::TakebackRequest(_) => {
-                let current_user = User::find_by_uuid(&game.current_player_id, &self.pool).await?;
-                let games = current_user
-                    .get_games_with_notifications(&self.pool)
-                    .await?;
+                let current_user = User::find_by_uuid(&game.current_player_id, &mut conn).await?;
+                let games = current_user.get_games_with_notifications(&mut conn).await?;
                 let mut game_responses = Vec::new();
                 for game in games {
-                    game_responses.push(GameResponse::new_from_db(&game, &self.pool).await?);
+                    game_responses.push(GameResponse::new_from_db(&game, &mut conn).await?);
                 }
                 messages.push(InternalServerMessage {
                     destination: MessageDestination::User(game.current_player_id),
@@ -119,76 +127,64 @@ impl GameControlHandler {
         })?
     }
 
-    async fn handle_takeback_request(&self) -> Result<Game> {
-        let game = self
-            .game
-            .write_game_control(&self.control, &self.pool)
-            .await?;
+    async fn handle_takeback_request(&self, conn: &mut DbConn<'_>) -> Result<Game> {
+        let game = self.game.write_game_control(&self.control, conn).await?;
         Ok(game)
     }
 
-    async fn handle_takeback_accept(&self) -> Result<Game> {
+    async fn handle_takeback_accept(&self, conn: &mut DbConn<'_>) -> Result<Game> {
         self.ensure_previous_gc_present()?;
-        let game = self.game.accept_takeback(&self.control, &self.pool).await?;
+        let game = self.game.accept_takeback(&self.control, conn).await?;
         Ok(game)
     }
 
-    async fn handle_resign(&self) -> Result<Game> {
-        let game = self.game.resign(&self.control, &self.pool).await?;
+    async fn handle_resign(&self, conn: &mut DbConn<'_>) -> Result<Game> {
+        let game = self.game.resign(&self.control, conn).await?;
         Ok(game)
     }
 
-    async fn handle_abort(&self) -> Result<()> {
-        Ok(self.game.delete(&self.pool).await?)
+    async fn handle_abort(&self, conn: &mut DbConn<'_>) -> Result<()> {
+        Ok(self.game.delete(conn).await?)
     }
 
-    async fn handle_draw_reject(&self) -> Result<Game> {
+    async fn handle_draw_reject(&self, conn: &mut DbConn<'_>) -> Result<Game> {
         self.ensure_previous_gc_present()?;
-        let game = self
-            .game
-            .write_game_control(&self.control, &self.pool)
-            .await?;
+        let game = self.game.write_game_control(&self.control, conn).await?;
         Ok(game)
     }
 
-    async fn handle_draw_offer(&self) -> Result<Game> {
-        let game = self
-            .game
-            .write_game_control(&self.control, &self.pool)
-            .await?;
+    async fn handle_draw_offer(&self, conn: &mut DbConn<'_>) -> Result<Game> {
+        let game = self.game.write_game_control(&self.control, conn).await?;
         Ok(game)
     }
 
-    async fn handle_draw_accept(&self) -> Result<Game> {
+    async fn handle_draw_accept(&self, conn: &mut DbConn<'_>) -> Result<Game> {
         self.ensure_previous_gc_present()?;
-        let game = self.game.accept_draw(&self.control, &self.pool).await?;
+        let game = self.game.accept_draw(&self.control, conn).await?;
         Ok(game)
     }
 
-    async fn handle_takeback_reject(&self) -> Result<Game> {
+    async fn handle_takeback_reject(&self, conn: &mut DbConn<'_>) -> Result<Game> {
         self.ensure_previous_gc_present()?;
-        let game = self
-            .game
-            .write_game_control(&self.control, &self.pool)
-            .await?;
+        let game = self.game.write_game_control(&self.control, conn).await?;
         Ok(game)
     }
 
-    async fn match_control(&self) -> Result<Game> {
+    async fn match_control(&self, conn: &mut DbConn<'_>) -> Result<Game> {
         Ok(match self.control {
             GameControl::Abort(_) => {
                 let mut game = self.game.clone();
-                self.handle_abort().await?;
+                self.handle_abort(conn).await?;
                 game.finished = true;
                 game
             }
-            GameControl::Resign(_) => self.handle_resign().await?,
-            GameControl::DrawOffer(_) => self.handle_draw_offer().await?,
-            GameControl::DrawAccept(_) => self.handle_draw_accept().await?,
-            GameControl::DrawReject(_) => self.handle_draw_reject().await?,
-            GameControl::TakebackRequest(_) => self.handle_takeback_request().await?,
-            GameControl::TakebackAccept(_) => self.handle_takeback_accept().await?,
-            GameControl::TakebackReject(_) => self.handle_takeback_reject().await?,
+            GameControl::Resign(_) => self.handle_resign(conn).await?,
+            GameControl::DrawOffer(_) => self.handle_draw_offer(conn).await?,
+            GameControl::DrawAccept(_) => self.handle_draw_accept(conn).await?,
+            GameControl::DrawReject(_) => self.handle_draw_reject(conn).await?,
+            GameControl::TakebackRequest(_) => self.handle_takeback_request(conn).await?,
+            GameControl::TakebackAccept(_) => self.handle_takeback_accept(conn).await?,
+            GameControl::TakebackReject(_) => self.handle_takeback_reject(conn).await?,
         })
     }
 

--- a/apis/src/websockets/api/game/join_handler.rs
+++ b/apis/src/websockets/api/game/join_handler.rs
@@ -10,7 +10,9 @@ use crate::{
     },
 };
 use anyhow::Result;
-use db_lib::{models::Game, DbPool};
+use db_lib::{get_conn, models::Game, DbPool};
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::AsyncConnection;
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -25,7 +27,7 @@ pub struct JoinHandler {
 
 impl JoinHandler {
     pub fn new(
-        game: Game,
+        game: &Game,
         username: &str,
         user_id: Uuid,
         received_from: actix::Recipient<WsMessage>,
@@ -34,7 +36,7 @@ impl JoinHandler {
     ) -> Self {
         Self {
             received_from,
-            game,
+            game: game.to_owned(),
             user_id,
             username: username.to_owned(),
             chat_storage,
@@ -43,34 +45,42 @@ impl JoinHandler {
     }
 
     pub async fn handle(&self) -> Result<Vec<InternalServerMessage>> {
+        let mut conn = get_conn(&self.pool).await?;
+
+        let game = conn
+            .transaction::<_, anyhow::Error, _>(move |tc| {
+                async move { Ok(Game::find_by_nanoid(&self.game.nanoid, tc).await?) }.scope_boxed()
+            })
+            .await?;
+
         let mut messages = Vec::new();
-        if let Ok(user) = UserResponse::from_uuid(&self.user_id, &self.pool).await {
+        if let Ok(user) = UserResponse::from_uuid(&self.user_id, &mut conn).await {
             messages.push(InternalServerMessage {
-                destination: MessageDestination::Game(self.game.nanoid.clone()),
+                destination: MessageDestination::Game(game.nanoid.clone()),
                 message: ServerMessage::Join(user),
             });
         } else {
             messages.push(InternalServerMessage {
-                destination: MessageDestination::Game(self.game.nanoid.clone()),
+                destination: MessageDestination::Game(game.nanoid.clone()),
                 message: ServerMessage::Join(UserResponse::for_anon(self.user_id)),
             });
         }
         messages.push(InternalServerMessage {
             destination: MessageDestination::Direct(self.received_from.clone()),
             message: ServerMessage::Game(Box::new(GameUpdate::Reaction(GameActionResponse {
-                game_id: self.game.nanoid.to_owned(),
-                game: GameResponse::new_from_db(&self.game, &self.pool).await?,
+                game_id: game.nanoid.to_owned(),
+                game: GameResponse::new_from_db(&game, &mut conn).await?,
                 game_action: GameReaction::Join,
                 user_id: self.user_id.to_owned(),
                 username: self.username.to_owned(),
             }))),
         });
-        let games = if self.user_id == self.game.white_id || self.user_id == self.game.black_id {
+        let games = if self.user_id == game.white_id || self.user_id == game.black_id {
             self.chat_storage.games_private.read().unwrap()
         } else {
             self.chat_storage.games_public.read().unwrap()
         };
-        if let Some(messages_to_push) = games.get(&self.game.nanoid) {
+        if let Some(messages_to_push) = games.get(&game.nanoid) {
             messages.push(InternalServerMessage {
                 destination: MessageDestination::User(self.user_id),
                 message: ServerMessage::Chat(messages_to_push.clone()),

--- a/apis/src/websockets/api/game/timeout_handler.rs
+++ b/apis/src/websockets/api/game/timeout_handler.rs
@@ -6,7 +6,9 @@ use crate::{
     websockets::internal_server_message::{InternalServerMessage, MessageDestination},
 };
 use anyhow::Result;
-use db_lib::{models::Game, DbPool};
+use db_lib::{get_conn, models::Game, DbPool};
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::AsyncConnection;
 use uuid::Uuid;
 
 pub struct TimeoutHandler {
@@ -17,9 +19,9 @@ pub struct TimeoutHandler {
 }
 
 impl TimeoutHandler {
-    pub fn new(game: Game, username: &str, user_id: Uuid, pool: &DbPool) -> Self {
+    pub fn new(game: &Game, username: &str, user_id: Uuid, pool: &DbPool) -> Self {
         Self {
-            game,
+            game: game.to_owned(),
             username: username.to_owned(),
             user_id,
             pool: pool.clone(),
@@ -27,27 +29,33 @@ impl TimeoutHandler {
     }
 
     pub async fn handle(&self) -> Result<Vec<InternalServerMessage>> {
+        let mut conn = get_conn(&self.pool).await?;
         let mut messages = Vec::new();
-        let game = self.game.check_time(&self.pool).await?;
-        let game_response = GameResponse::new_from_db(&game, &self.pool).await?;
 
+        let game = conn
+            .transaction::<_, anyhow::Error, _>(move |tc| {
+                async move {
+                    // find_by_nanoid automatically times the game out if needed
+                    Ok(Game::find_by_nanoid(&self.game.nanoid, tc).await?)
+                }
+                .scope_boxed()
+            })
+            .await?;
+
+        let game_response = GameResponse::new_from_db(&game, &mut conn).await?;
         if game.finished {
             messages.push(InternalServerMessage {
                 destination: MessageDestination::Global,
                 message: ServerMessage::Game(Box::new(GameUpdate::Reaction(GameActionResponse {
                     game_action: GameReaction::TimedOut,
                     game: game_response,
-                    game_id: self.game.nanoid.clone(),
+                    game_id: game.nanoid,
                     user_id: self.user_id,
                     username: self.username.clone(),
                 }))),
             });
         }
-        // TODO: Figure why/whether we need this code :D
-        // messages.push(InternalServerMessage {
-        //     destination: MessageDestination::Game(self.game.nanoid.clone()),
-        //     message: ServerMessage::Game(TimeoutCheck(game_response)),
-        // });
+
         Ok(messages)
     }
 }

--- a/apis/src/websockets/api/game/turn_handler.rs
+++ b/apis/src/websockets/api/game/turn_handler.rs
@@ -6,10 +6,15 @@ use crate::{
     websockets::internal_server_message::{InternalServerMessage, MessageDestination},
 };
 use anyhow::Result;
-use db_lib::{models::Game, models::User, DbPool};
+use db_lib::{
+    get_conn,
+    models::{Game, User},
+    DbPool,
+};
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::AsyncConnection;
 use hive_lib::{GameError, State, Turn};
 use shared_types::TimeMode;
-
 use uuid::Uuid;
 
 pub struct TurnHandler {
@@ -21,9 +26,9 @@ pub struct TurnHandler {
 }
 
 impl TurnHandler {
-    pub fn new(turn: Turn, game: Game, username: &str, user_id: Uuid, pool: &DbPool) -> Self {
+    pub fn new(turn: Turn, game: &Game, username: &str, user_id: Uuid, pool: &DbPool) -> Self {
         Self {
-            game,
+            game: game.to_owned(),
             user_id,
             username: username.to_owned(),
             pool: pool.clone(),
@@ -32,7 +37,7 @@ impl TurnHandler {
     }
 
     pub async fn handle(&self) -> Result<Vec<InternalServerMessage>> {
-        let mut messages = Vec::new();
+        let mut conn = get_conn(&self.pool).await?;
         self.users_turn()?;
         let (piece, position) = match self.turn {
             Turn::Move(piece, position) => (piece, position),
@@ -42,27 +47,31 @@ impl TurnHandler {
                 turn: format!("{}", self.game.turn),
             })?,
         };
-
         let mut state = State::new_from_str(&self.game.history, &self.game.game_type)?;
         state.play_turn_from_position(piece, position)?;
-        let game = self.game.update_gamestate(&state, &self.pool).await?;
-        let next_to_move = User::find_by_uuid(&game.current_player_id, &self.pool).await?;
-        let games = next_to_move
-            .get_games_with_notifications(&self.pool)
+
+        let game = conn
+            .transaction::<_, anyhow::Error, _>(move |tc| {
+                async move { Ok(self.game.update_gamestate(&state, tc).await?) }.scope_boxed()
+            })
             .await?;
+
+        let mut messages = Vec::new();
+        let next_to_move = User::find_by_uuid(&game.current_player_id, &mut conn).await?;
+        let games = next_to_move.get_games_with_notifications(&mut conn).await?;
         let mut game_responses = Vec::new();
         for game in games {
-            game_responses.push(GameResponse::new_from_db(&game, &self.pool).await?);
+            game_responses.push(GameResponse::new_from_db(&game, &mut conn).await?);
         }
         messages.push(InternalServerMessage {
             destination: MessageDestination::User(game.current_player_id),
             message: ServerMessage::Game(Box::new(GameUpdate::Urgent(game_responses))),
         });
-        let response = GameResponse::new_from_db(&game, &self.pool).await?;
+        let response = GameResponse::new_from_db(&game, &mut conn).await?;
         messages.push(InternalServerMessage {
-            destination: MessageDestination::Game(self.game.nanoid.clone()),
+            destination: MessageDestination::Game(game.nanoid.clone()),
             message: ServerMessage::Game(Box::new(GameUpdate::Reaction(GameActionResponse {
-                game_id: self.game.nanoid.to_owned(),
+                game_id: game.nanoid.to_owned(),
                 game: response.clone(),
                 game_action: GameReaction::Turn(self.turn.clone()),
                 user_id: self.user_id.to_owned(),

--- a/apis/src/websockets/start_connection.rs
+++ b/apis/src/websockets/start_connection.rs
@@ -3,7 +3,7 @@ use actix::Addr;
 use actix_identity::Identity;
 use actix_web::{get, web::Data, web::Payload, Error, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
-use db_lib::{models::User, DbPool};
+use db_lib::{get_conn, models::User, DbPool};
 use uuid::Uuid;
 
 #[get("/ws/")]
@@ -18,18 +18,23 @@ pub async fn start_connection(
     if let Some(id) = identity {
         if let Ok(id_string) = id.id() {
             if let Ok(uuid) = Uuid::parse_str(&id_string) {
-                if let Ok(user) = User::find_by_uuid(&uuid, &pool).await {
-                    println!("Welcome {}!", user.username);
-                    let ws = WsConnection::new(
-                        Some(uuid),
-                        Some(user.username),
-                        Some(user.admin),
-                        srv.get_ref().clone(),
-                        chat_storage.clone(),
-                        pool.get_ref().clone(),
-                    );
-                    let resp = ws::start(ws, &req, stream)?;
-                    return Ok(resp);
+                match get_conn(&pool).await {
+                    Ok(mut conn) => {
+                        if let Ok(user) = User::find_by_uuid(&uuid, &mut conn).await {
+                            println!("Welcome {}!", user.username);
+                            let ws = WsConnection::new(
+                                Some(uuid),
+                                Some(user.username),
+                                Some(user.admin),
+                                srv.get_ref().clone(),
+                                chat_storage.clone(),
+                                pool.get_ref().clone(),
+                            );
+                            let resp = ws::start(ws, &req, stream)?;
+                            return Ok(resp);
+                        }
+                    }
+                    Err(err) => println!("Could not establish database connection: {err}"),
                 }
             }
         }

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -11,14 +11,13 @@ pub mod models;
 pub mod schema;
 
 pub type DbPool = Pool<AsyncPgConnection>;
+pub type DbConn<'a> = PooledConnection<'a, AsyncDieselConnectionManager<AsyncPgConnection>>;
 
 pub async fn get_pool(db_uri: &str) -> Result<DbPool, PoolError> {
     let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(db_uri);
     Pool::builder().build(manager).await
 }
 
-pub async fn get_conn(
-    pool: &DbPool,
-) -> Result<PooledConnection<AsyncDieselConnectionManager<AsyncPgConnection>>, DieselError> {
+pub async fn get_conn(pool: &DbPool) -> Result<DbConn, DieselError> {
     pool.get().await.map_err(|e| QueryBuilderError(e.into()))
 }

--- a/db/src/main.rs
+++ b/db/src/main.rs
@@ -1,6 +1,8 @@
-use db_lib::config::DbConfig;
-use db_lib::get_pool;
-use db_lib::models::{NewUser, User};
+use db_lib::{
+    config::DbConfig,
+    get_conn, get_pool,
+    models::{NewUser, User},
+};
 
 #[tokio::main]
 async fn main() {
@@ -9,10 +11,11 @@ async fn main() {
         .await
         .expect("Failed to get pool");
     let new_user = NewUser::new("leex", "hunter2", "leex").expect("Failed to make new_user");
-    let user = User::create(&new_user, pool)
+    let mut conn = get_conn(pool).await.expect("to get connection");
+    let user = User::create(new_user, &mut conn)
         .await
         .expect("Failed to create user");
     println!("User {:?}", user);
-    let deleted = user.delete(pool).await.expect("Failed to delete user");
+    let deleted = user.delete(&mut conn).await.expect("Failed to delete user");
     println!("Deleted {:?}", deleted);
 }

--- a/db/src/models/challenge.rs
+++ b/db/src/models/challenge.rs
@@ -1,12 +1,11 @@
 use crate::{
     db_error::DbError,
-    get_conn,
     models::user::User,
     schema::{
         challenges::{self, nanoid as nanoid_field, opponent_id as opponent_id_field},
         users,
     },
-    DbPool,
+    DbConn,
 };
 use chrono::prelude::*;
 use diesel::prelude::*;
@@ -129,24 +128,24 @@ pub struct Challenge {
 }
 
 impl Challenge {
-    pub async fn create(new_challenge: &NewChallenge, pool: &DbPool) -> Result<Challenge, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn create(
+        new_challenge: &NewChallenge,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Challenge, DbError> {
         Ok(diesel::insert_into(challenges::table)
             .values(new_challenge)
             .get_result(conn)
             .await?)
     }
 
-    pub async fn get_public(pool: &DbPool) -> Result<Vec<Challenge>, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn get_public(conn: &mut DbConn<'_>) -> Result<Vec<Challenge>, DbError> {
         Ok(challenges::table
             .filter(challenges::visibility.eq("Public"))
             .get_results(conn)
             .await?)
     }
 
-    pub async fn get_own(user: Uuid, pool: &DbPool) -> Result<Vec<Challenge>, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn get_own(user: Uuid, conn: &mut DbConn<'_>) -> Result<Vec<Challenge>, DbError> {
         Ok(challenges::table
             .filter(challenges::challenger_id.eq(user))
             .get_results(conn)
@@ -155,9 +154,8 @@ impl Challenge {
 
     pub async fn get_public_exclude_user(
         user: Uuid,
-        pool: &DbPool,
+        conn: &mut DbConn<'_>,
     ) -> Result<Vec<Challenge>, DbError> {
-        let conn = &mut get_conn(pool).await?;
         Ok(challenges::table
             .filter(challenges::visibility.eq("Public"))
             .filter(challenges::challenger_id.ne(user))
@@ -165,34 +163,32 @@ impl Challenge {
             .await?)
     }
 
-    pub async fn direct_challenges(id: Uuid, pool: &DbPool) -> Result<Vec<Challenge>, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn direct_challenges(
+        id: Uuid,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Vec<Challenge>, DbError> {
         Ok(challenges::table
             .filter(opponent_id_field.eq(id))
             .get_results(conn)
             .await?)
     }
 
-    pub async fn find_by_uuid(id: &Uuid, pool: &DbPool) -> Result<Challenge, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn find_by_uuid(id: &Uuid, conn: &mut DbConn<'_>) -> Result<Challenge, DbError> {
         Ok(challenges::table.find(id).first(conn).await?)
     }
 
-    pub async fn find_by_nanoid(u: &str, pool: &DbPool) -> Result<Challenge, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn find_by_nanoid(u: &str, conn: &mut DbConn<'_>) -> Result<Challenge, DbError> {
         Ok(challenges::table
             .filter(nanoid_field.eq(u))
             .first(conn)
             .await?)
     }
 
-    pub async fn get_challenger(&self, pool: &DbPool) -> Result<User, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn get_challenger(&self, conn: &mut DbConn<'_>) -> Result<User, DbError> {
         Ok(users::table.find(&self.challenger_id).first(conn).await?)
     }
 
-    pub async fn delete(&self, pool: &DbPool) -> Result<(), DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn delete(&self, conn: &mut DbConn<'_>) -> Result<(), DbError> {
         diesel::delete(challenges::table.find(self.id))
             .execute(conn)
             .await?;

--- a/db/src/models/game_user.rs
+++ b/db/src/models/game_user.rs
@@ -1,8 +1,8 @@
 use crate::{
     db_error::DbError,
     models::{Game, User},
-    schema::{games_users, games_users::dsl::games_users as games_users_table},
-    {get_conn, DbPool},
+    schema::games_users::{self, dsl::games_users as games_users_table},
+    DbConn,
 };
 use diesel::{prelude::*, Identifiable, Insertable, Queryable};
 use diesel_async::RunQueryDsl;
@@ -23,8 +23,7 @@ impl GameUser {
         Self { game_id, user_id }
     }
 
-    pub async fn insert(&self, pool: &DbPool) -> Result<(), DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn insert(&self, conn: &mut DbConn<'_>) -> Result<(), DbError> {
         self.insert_into(games_users_table).execute(conn).await?;
         Ok(())
     }

--- a/db/src/models/user.rs
+++ b/db/src/models/user.rs
@@ -1,7 +1,6 @@
 use super::rating::Rating;
 use crate::{
     db_error::DbError,
-    get_conn,
     models::{Game, GameUser, NewRating},
     schema::{
         games::{self, current_player_id, finished},
@@ -14,14 +13,14 @@ use crate::{
             },
         },
     },
-    DbPool,
+    DbConn,
 };
 use chrono::{DateTime, Utc};
 use diesel::{
     dsl::exists, query_dsl::BelongingToDsl, select, ExpressionMethods, Identifiable, Insertable,
     PgTextExpressionMethods, QueryDsl, Queryable, SelectableHelper,
 };
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl};
+use diesel_async::RunQueryDsl;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -126,35 +125,26 @@ pub struct User {
 }
 
 impl User {
-    pub async fn create(new_user: &NewUser, pool: &DbPool) -> Result<User, DbError> {
-        let connection = &mut get_conn(pool).await?;
-        connection
-            .transaction::<_, DbError, _>(|conn| {
-                async move {
-                    let user: User = diesel::insert_into(users::table)
-                        .values(new_user)
-                        .get_result(conn)
-                        .await?;
-                    for game_speed in GameSpeed::all_rated().into_iter() {
-                        diesel::insert_into(ratings::table)
-                            .values(NewRating::for_uuid(&user.id, game_speed))
-                            .execute(conn)
-                            .await?;
-                    }
-                    Ok(user)
-                }
-                .scope_boxed()
-            })
-            .await
+    pub async fn create(new_user: NewUser, conn: &mut DbConn<'_>) -> Result<User, DbError> {
+        let user: User = diesel::insert_into(users::table)
+            .values(new_user)
+            .get_result(conn)
+            .await?;
+        for game_speed in GameSpeed::all_rated().into_iter() {
+            diesel::insert_into(ratings::table)
+                .values(NewRating::for_uuid(&user.id, game_speed))
+                .execute(conn)
+                .await?;
+        }
+        Ok(user)
     }
 
     pub async fn edit(
         &self,
         new_password: &str,
         new_email: &str,
-        pool: &DbPool,
+        conn: &mut DbConn<'_>,
     ) -> Result<User, DbError> {
-        let conn = &mut get_conn(pool).await?;
         Ok(match (new_password.is_empty(), new_email.is_empty()) {
             (true, true) => users_table.find(&self.id).first(conn).await?,
             (true, false) => {
@@ -182,32 +172,31 @@ impl User {
         })
     }
 
-    pub async fn find_by_uuid(uuid: &Uuid, pool: &DbPool) -> Result<User, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn find_by_uuid(uuid: &Uuid, conn: &mut DbConn<'_>) -> Result<User, DbError> {
         Ok(users_table.find(uuid).first(conn).await?)
     }
 
-    pub async fn find_by_username(username: &str, pool: &DbPool) -> Result<User, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn find_by_username(username: &str, conn: &mut DbConn<'_>) -> Result<User, DbError> {
         Ok(users_table
             .filter(normalized_username.eq(username.to_lowercase()))
             .first(conn)
             .await?)
     }
 
-    pub async fn search_usernames(pattern: &str, pool: &DbPool) -> Result<Vec<User>, DbError> {
+    pub async fn search_usernames(
+        pattern: &str,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Vec<User>, DbError> {
         if pattern.is_empty() {
             return Ok(vec![]);
         }
-        let conn = &mut get_conn(pool).await?;
         Ok(users_table
             .filter(normalized_username.ilike(format!("%{}%", pattern)))
             .load(conn)
             .await?)
     }
 
-    pub async fn username_exists(username: &str, pool: &DbPool) -> Result<bool, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn username_exists(username: &str, conn: &mut DbConn<'_>) -> Result<bool, DbError> {
         Ok(select(exists(
             users_table.filter(normalized_username.eq(username.to_lowercase())),
         ))
@@ -215,23 +204,23 @@ impl User {
         .await?)
     }
 
-    pub async fn find_by_email(email: &str, pool: &DbPool) -> Result<User, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn find_by_email(email: &str, conn: &mut DbConn<'_>) -> Result<User, DbError> {
         Ok(users_table
             .filter(email_field.eq(email.to_lowercase()))
             .first(conn)
             .await?)
     }
 
-    pub async fn delete(&self, pool: &DbPool) -> Result<usize, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn delete(&self, conn: &mut DbConn<'_>) -> Result<usize, DbError> {
         Ok(diesel::delete(users_table.find(&self.id))
             .execute(conn)
             .await?)
     }
 
-    pub async fn get_games_with_notifications(&self, pool: &DbPool) -> Result<Vec<Game>, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn get_games_with_notifications(
+        &self,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Vec<Game>, DbError> {
         Ok(GameUser::belonging_to(self)
             .inner_join(games::table)
             .select(Game::as_select())
@@ -241,8 +230,7 @@ impl User {
             .await?)
     }
 
-    pub async fn get_urgent_nanoids(&self, pool: &DbPool) -> Result<Vec<String>, DbError> {
-        let conn = &mut get_conn(pool).await?;
+    pub async fn get_urgent_nanoids(&self, conn: &mut DbConn<'_>) -> Result<Vec<String>, DbError> {
         Ok(GameUser::belonging_to(self)
             .inner_join(games::table)
             .select(Game::as_select())
@@ -258,9 +246,8 @@ impl User {
     pub async fn get_top_users(
         game_speed: &GameSpeed,
         limit: i64,
-        pool: &DbPool,
+        conn: &mut DbConn<'_>,
     ) -> Result<Vec<(User, Rating)>, DbError> {
-        let conn = &mut get_conn(pool).await?;
         Ok(users::table
             .inner_join(ratings::table)
             .filter(ratings::deviation.le(shared_types::RANKABLE_DEVIATION))


### PR DESCRIPTION
This change gets the code base away from making multiple pools all the time.
It now has one (1) pool per request and every DB interaction for that request is on the same connection.
Now `Handler`s get a `pool`, make a `connection` and then from everything in the models uses a `DbConn` instead of a `DbPool`
`Handler`s are now responsible for opening a `transaction` if they are doing writes to multiple `models`.