### PR TITLE
add "opponent" label to takeback request

### DIFF
--- a/apis/src/components/molecules/control_buttons.rs
+++ b/apis/src/components/molecules/control_buttons.rs
@@ -174,57 +174,71 @@ pub fn ControlButtons() -> impl IntoView {
                 when=game_state.is_finished()
                 fallback=move || {
                     view! {
-                        <div class="flex justify-around items-center grow shrink">
-                            <div class="relative">
-                                <ConfirmButton
-                                    game_control=store_value(GameControl::Abort(color()))
-                                    user_id=user_id()
-                                    hidden=memo_for_hidden_class(move || {
-                                        (game_state.signal)().state.turn > 1
-                                    })
-                                />
+                        <div class="flex flex-col w-full">
+                            <div class="flex justify-around items-center grow shrink">
+                                <div class="relative">
+                                    <ConfirmButton
+                                        game_control=store_value(GameControl::Abort(color()))
+                                        user_id=user_id()
+                                        hidden=memo_for_hidden_class(move || {
+                                            (game_state.signal)().state.turn > 1
+                                        })
+                                    />
 
-                                <ConfirmButton
-                                    game_control=store_value(GameControl::TakebackRequest(color()))
-                                    user_id=user_id()
-                                    hidden=memo_for_hidden_class(move || {
-                                        pending_takeback() || (game_state.signal)().state.turn < 2
-                                    })
-                                />
+                                    <ConfirmButton
+                                        game_control=store_value(
+                                            GameControl::TakebackRequest(color()),
+                                        )
 
-                                <AcceptDenyGc
-                                    game_control=store_value(GameControl::TakebackAccept(color()))
+                                        user_id=user_id()
+                                        hidden=memo_for_hidden_class(move || {
+                                            pending_takeback() || (game_state.signal)().state.turn < 2
+                                        })
+                                    />
+
+                                    <AcceptDenyGc
+                                        game_control=store_value(
+                                            GameControl::TakebackAccept(color()),
+                                        )
+
+                                        user_id=user_id()
+                                        hidden=memo_for_hidden_class(move || !pending_takeback())
+                                    />
+                                    <AcceptDenyGc
+                                        game_control=store_value(
+                                            GameControl::TakebackReject(color()),
+                                        )
+
+                                        user_id=user_id()
+                                        hidden=memo_for_hidden_class(move || !pending_takeback())
+                                    />
+                                </div>
+                                <div class="relative">
+                                    <ConfirmButton
+                                        game_control=store_value(GameControl::DrawOffer(color()))
+                                        user_id=user_id()
+                                        hidden=memo_for_hidden_class(pending_draw)
+                                    />
+
+                                    <AcceptDenyGc
+                                        game_control=store_value(GameControl::DrawAccept(color()))
+                                        user_id=user_id()
+                                        hidden=memo_for_hidden_class(move || !pending_draw())
+                                    />
+                                    <AcceptDenyGc
+                                        game_control=store_value(GameControl::DrawReject(color()))
+                                        user_id=user_id()
+                                        hidden=memo_for_hidden_class(move || !pending_draw())
+                                    />
+                                </div>
+                                <ConfirmButton
+                                    game_control=store_value(GameControl::Resign(color()))
                                     user_id=user_id()
-                                    hidden=memo_for_hidden_class(move || !pending_takeback())
-                                />
-                                <AcceptDenyGc
-                                    game_control=store_value(GameControl::TakebackReject(color()))
-                                    user_id=user_id()
-                                    hidden=memo_for_hidden_class(move || !pending_takeback())
                                 />
                             </div>
-                            <div class="relative">
-                                <ConfirmButton
-                                    game_control=store_value(GameControl::DrawOffer(color()))
-                                    user_id=user_id()
-                                    hidden=memo_for_hidden_class(pending_draw)
-                                />
-
-                                <AcceptDenyGc
-                                    game_control=store_value(GameControl::DrawAccept(color()))
-                                    user_id=user_id()
-                                    hidden=memo_for_hidden_class(move || !pending_draw())
-                                />
-                                <AcceptDenyGc
-                                    game_control=store_value(GameControl::DrawReject(color()))
-                                    user_id=user_id()
-                                    hidden=memo_for_hidden_class(move || !pending_draw())
-                                />
+                            <div class=memo_for_hidden_class(move || !pending_takeback())>
+                            <span class="font-bold"> "Opponent wants a takeback"</span>
                             </div>
-                            <ConfirmButton
-                                game_control=store_value(GameControl::Resign(color()))
-                                user_id=user_id()
-                            />
                         </div>
                     }
                 }


### PR DESCRIPTION
Add simple label to distinguish better takeback accept/reject state from confirm state, 