### PR TITLE
analysis improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,8 +418,7 @@ dependencies = [
  "actix-web-actors",
  "anyhow",
  "argon2",
- "base64 0.22.1",
- "bincode",
+ "bimap",
  "cfg-if",
  "chrono",
  "console_error_panic_hook",
@@ -580,10 +579,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bimap"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 dependencies = [
  "serde",
 ]
@@ -2888,11 +2887,12 @@ dependencies = [
 
 [[package]]
 name = "sequential_gen"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da850bb1f2deffd0d19c1a1fcf445cb747aa401517c96eff7c6d965de792175d"
+checksum = "3d630b1418311e028ceb45e1e567845501a9d9c770a258b80d2edc025ffad17c"
 dependencies = [
  "lazy_static",
+ "uuid",
 ]
 
 [[package]]
@@ -3481,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "tree-ds"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a67f3e9bee38b6a34b29a98abf5fc5b13aea6a7db36753d260735af7633a8"
+checksum = "ba93bd6a2167eae091428ff34bbef09edd870f941ff736afdb02e05585e258bd"
 dependencies = [
  "lazy_static",
  "sequential_gen",
@@ -3588,9 +3588,9 @@ checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,10 @@ rand_core = "0.6"
 cookie = "0.18"
 skillratings = "0.26"
 chrono = { version = "0.4", features = ["serde"] }
-tree-ds = { version = "0.1.4", features = ["serde"] }
-bincode = { version = "1.3.3"}
-base64 = { version = "0.22.1"}
-leptix_primitives = { version = "0.2.0" }
 itertools = "0.13.0"
+leptix_primitives = { version = "0.2.0" }
+tree-ds = {version = "0.1.5", features = ["serde", "compact_serde"] }
+bimap = {version = "0.6.3", features = ["serde"] }
 # Defines a size-optimized profile for the WASM bundle in release mode
 [profile.wasm-release]
 inherits = "release"

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -51,8 +51,7 @@ wasm-bindgen = { workspace = true}
 web-sys = { workspace = true }
 leptix_primitives = {workspace = true}
 tree-ds = {workspace = true}
-bincode = {workspace = true}
-base64 = {workspace = true}
+bimap = {workspace = true}
 [features]
 csr = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]

--- a/apis/src/components/atoms/piece.rs
+++ b/apis/src/components/atoms/piece.rs
@@ -4,7 +4,7 @@ use crate::components::organisms::analysis::AnalysisSignal;
 use crate::pages::play::CurrentConfirm;
 use crate::providers::game_state::GameStateSignal;
 use crate::providers::Config;
-use hive_lib::{Bug, Piece, Position};
+use hive_lib::{Bug, GameStatus, Piece, Position};
 use leptos::*;
 use web_sys::MouseEvent;
 
@@ -71,7 +71,12 @@ pub fn Piece(
     let onclick = move |evt: MouseEvent| {
         evt.stop_propagation();
         let in_analysis = analysis.get_untracked().is_some();
-        if in_analysis || game_state.is_move_allowed() {
+        let is_finished = matches!(
+            game_state.signal.get_untracked().state.game_status,
+            GameStatus::Finished(_)
+        );
+
+        if (in_analysis && !is_finished) || game_state.is_move_allowed() {
             match piece_type {
                 PieceType::Board => {
                     game_state.show_moves(piece, position);

--- a/apis/src/components/atoms/target.rs
+++ b/apis/src/components/atoms/target.rs
@@ -30,13 +30,16 @@ pub fn Target(
                 }
                 analysis.update(|analysis| {
                     if let Some(analysis) = analysis {
-                        let moves = game_state.signal.get_untracked().state.history.moves;
-                        let last_move = moves.last().unwrap().clone();
-                        if last_move.0 == "pass" {
+                        let state = game_state.signal.get_untracked().state;
+                        let moves = state.history.moves;
+                        let hashes = state.hashes;
+                        let last_index = moves.len() - 1;
+                        if moves[last_index].0 == "pass" {
                             //if move is pass, add prev move
-                            analysis.add_node(moves[moves.len() - 2].clone());
+                            analysis
+                                .add_node(moves[last_index - 1].clone(), hashes[last_index - 1]);
                         }
-                        analysis.add_node(last_move);
+                        analysis.add_node(moves[last_index].clone(), hashes[last_index]);
                     }
                 });
             });

--- a/apis/src/components/organisms/analysis/atoms.rs
+++ b/apis/src/components/organisms/analysis/atoms.rs
@@ -2,6 +2,7 @@ use super::TreeNode;
 use crate::components::organisms::analysis::{AnalysisSignal, ToggleStates};
 use crate::components::organisms::reserve::Alignment;
 use crate::components::organisms::reserve::Reserve;
+use crate::providers::game_state::GameStateSignal;
 use hive_lib::Color;
 use leptix_primitives::components::collapsible::{
     CollapsibleContent, CollapsibleRoot, CollapsibleTrigger,
@@ -27,6 +28,11 @@ pub fn UndoButton() -> impl IntoView {
                     let new_current = node.get_parent_id();
                     if let Some(new_current) = new_current {
                         a.update_node(new_current);
+                        if let Ok(tree) = a.tree.get_subtree(&node.get_node_id(), None) {
+                            tree.get_nodes().iter().for_each(|n| {
+                                a.hashes.remove_by_right(&n.get_node_id());
+                            });
+                        };
                         a.tree
                             .remove_node(
                                 &node.get_node_id(),
@@ -127,19 +133,14 @@ pub fn HistoryButton(
 }
 
 #[component]
-pub fn HistoryMove(node: Node<i32, TreeNode>) -> impl IntoView {
+pub fn HistoryMove(node: Node<i32, TreeNode>, current_path: Memo<Vec<i32>>) -> impl IntoView {
     let analysis = expect_context::<AnalysisSignal>().0;
     let value = node.get_value().unwrap();
     let node_id = node.get_node_id();
     let class = move || {
         let mut class =
             "w-full transition-transform duration-300 transform hover:bg-pillbug-teal active:scale-95";
-        if analysis
-            .get()
-            .unwrap()
-            .current_node
-            .map_or(false, |n| n.get_node_id() == node_id)
-        {
+        if current_path.get().first() == Some(&node_id) {
             class = "w-full transition-transform duration-300 transform hover:bg-pillbug-teal bg-orange-twilight active:scale-95"
         }
         class
@@ -151,15 +152,29 @@ pub fn HistoryMove(node: Node<i32, TreeNode>) -> impl IntoView {
             }
         });
     };
+    let history_index = value.turn - 1;
+    let game_state = expect_context::<GameStateSignal>();
+    let repetitions = create_read_slice(game_state.signal, |gs| gs.state.repeating_moves.clone());
+    let rep = move || {
+        if repetitions.get().contains(&history_index) && current_path.get().contains(&node_id) {
+            String::from(" ↺")
+        } else {
+            String::new()
+        }
+    };
     view! {
         <div class=class on:click=onclick>
-            {format!("{}. {} {}", value.turn, value.piece, value.position)}
+            {move || format!("{}. {} {} {}", value.turn, value.piece, value.position, rep())}
         </div>
     }
 }
 
 #[component]
-pub fn CollapsibleMove(node: Node<i32, TreeNode>, children: ChildrenFn) -> impl IntoView {
+pub fn CollapsibleMove(
+    node: Node<i32, TreeNode>,
+    current_path: Memo<Vec<i32>>,
+    children: ChildrenFn,
+) -> impl IntoView {
     let closed_toggles = expect_context::<ToggleStates>().0;
     let node_id = node.get_node_id();
     let is_open = !closed_toggles.get().contains(&node_id);
@@ -200,7 +215,7 @@ pub fn CollapsibleMove(node: Node<i32, TreeNode>, children: ChildrenFn) -> impl 
                         </svg>
                     </button>
                 </CollapsibleTrigger>
-                <HistoryMove node=node.clone()/>
+                <HistoryMove  current_path node=node.clone()/>
             </div>
             <CollapsibleContent children=children.clone() attr:class="nested-content"/>
         </CollapsibleRoot>

--- a/apis/src/components/organisms/analysis/save_and_load.rs
+++ b/apis/src/components/organisms/analysis/save_and_load.rs
@@ -1,4 +1,3 @@
-use base64::{engine::general_purpose, Engine as _};
 use core::str;
 use hive_lib::History;
 use leptos::*;
@@ -7,8 +6,7 @@ use web_sys::{js_sys::Array, Blob, Url};
 
 use super::AnalysisTree;
 use crate::{
-    components::organisms::analysis::AnalysisSignal,
-    providers::game_state::{GameState, GameStateSignal},
+    components::organisms::analysis::AnalysisSignal, providers::game_state::GameStateSignal,
 };
 use std::path::Path;
 use wasm_bindgen::closure::Closure;
@@ -44,15 +42,14 @@ pub fn DownloadTree(tree: AnalysisTree) -> impl IntoView {
 }
 
 fn blob_and_filename(tree: AnalysisTree) -> (Blob, String) {
-    let tree = bincode::serialize(&tree).unwrap();
-    let tree = general_purpose::STANDARD.encode(tree);
+    let tree = serde_json::to_string(&tree).unwrap();
     let file = Array::from(&JsValue::from(tree));
     let date = chrono::offset::Local::now()
         .format("%d-%b-%Y_%H:%M:%S")
         .to_string();
     (
         Blob::new_with_u8_array_sequence(&file).unwrap(),
-        format!("analysis_{date}.hat"),
+        format!("analysis_{date}.json"),
     )
 }
 
@@ -60,6 +57,7 @@ fn blob_and_filename(tree: AnalysisTree) -> (Blob, String) {
 pub fn LoadTree() -> impl IntoView {
     let input_ref = create_node_ref::<html::Input>();
     let analysis = expect_context::<AnalysisSignal>().0;
+    let game_state = expect_context::<GameStateSignal>();
     let loaded = RwSignal::new(false);
     let div_ref = NodeRef::<html::Div>::new();
     div_ref.on_load(move |_| {
@@ -68,21 +66,13 @@ pub fn LoadTree() -> impl IntoView {
             .expect("div to be loaded")
             .on_mount(move |_| loaded.set(true));
     });
-    let maybe_update_tree = move |maybe_tree: Option<AnalysisTree>| {
-        if let Some(tree) = maybe_tree {
-            analysis.update(|a| {
-                if let Some(a) = a {
-                    a.reset();
-                    a.tree = tree.tree;
-                    if let Some(current_node) = tree.current_node {
-                        a.update_node(current_node.get_node_id());
-                    }
-                }
-            });
-            Some(())
-        } else {
-            None
-        }
+    let update_tree = move |tree: AnalysisTree| -> Option<()> {
+        analysis.update(|a| {
+            if let Some(a) = a {
+                *a = tree
+            }
+        });
+        Some(())
     };
     view! {
         <div ref=div_ref class="m-1 w-1/3 h-7">
@@ -92,10 +82,8 @@ pub fn LoadTree() -> impl IntoView {
                     let from_hat = Closure::new(move |string: JsValue| {
                         let res = string
                             .as_string()
-                            .and_then(|string| general_purpose::STANDARD.decode(string).ok())
-                            .and_then(|bytes| {
-                                maybe_update_tree(bincode::deserialize::<AnalysisTree>(&bytes).ok())
-                            });
+                            .and_then(|string| serde_json::from_str::<AnalysisTree>(&string).ok())
+                            .and_then(update_tree);
                         if res.is_none() {
                             logging::log!("Couldn't open file");
                         }
@@ -106,12 +94,10 @@ pub fn LoadTree() -> impl IntoView {
                             .and_then(|string| { History::from_pgn_str(string).ok() })
                             .and_then(|history| hive_lib::State::new_from_history(&history).ok())
                             .and_then(|state| {
-                                let mut new_gs = GameState::new();
-                                new_gs.state = state;
-                                let new_gs_signal = GameStateSignal::new();
-                                new_gs_signal.signal.update_untracked(|gs| *gs = new_gs);
-                                maybe_update_tree(AnalysisTree::from_state(new_gs_signal))
-                            });
+                                game_state.signal.update(|gs| gs.state = state);
+                                AnalysisTree::from_state(game_state)
+                            })
+                            .and_then(update_tree);
                         if res.is_none() {
                             logging::log!("Couldn't open file");
                         }
@@ -137,7 +123,7 @@ pub fn LoadTree() -> impl IntoView {
                                         .map_or_else(
                                             || logging::log!("Couldn't open file"),
                                             |ext| {
-                                                if ext == "hat" {
+                                                if ext == "json" {
                                                     let _ = file.text().then(&from_hat);
                                                 } else if ext == "pgn" {
                                                     let _ = file.text().then(&from_pgn);
@@ -151,7 +137,7 @@ pub fn LoadTree() -> impl IntoView {
                                 type="file"
                                 id="load-analysis"
                                 class="hidden"
-                                accept=".hat,.pgn"
+                                accept=".json,.pgn"
                             />
                         </label>
                     }

--- a/apis/src/components/organisms/dropdowns/learn.rs
+++ b/apis/src/components/organisms/dropdowns/learn.rs
@@ -23,6 +23,13 @@ pub fn LearnDropdown() -> impl IntoView {
             >
                 Rules
             </a>
+            <a
+                class=COMMON_LINK_STYLE
+                on:click=onclick_close
+                href="https://hivegame.com/analysis"
+            >
+                Analysis
+            </a>
         </Hamburger>
     }
 }

--- a/apis/src/components/organisms/dropdowns/mobile.rs
+++ b/apis/src/components/organisms/dropdowns/mobile.rs
@@ -42,6 +42,13 @@ pub fn MobileDropdown() -> impl IntoView {
                 >
                     Rules
                 </a>
+                <a
+                    class=COMMON_LINK_STYLE
+                    on:click=onclick_close
+                    href="https://hivegame.com/analysis"
+                >
+                    Rules
+                </a>
                 Tournament:
                 <a class=COMMON_LINK_STYLE on:click=onclick_close href="/tournaments">
                     View Tournaments


### PR DESCRIPTION
If a state has been reached previously it willl jump to that tree in the node if the turn numbers match.

If at the current node a 3 move rep has ocurred mark all corresponding turns with the rep symbol

A bijective map is needed instead of regular hashmap since we need to search by both sides (by "key" and "value") for insert and delete respectivly

With  tree_ds 0.15, we can use the [compact_serde](https://github.com/clementwanjau/tree-ds/issues/12) feature and the size of the file will scale with the number of nodes, not the complexity of the tree. The size seems to be 1kb per 10 nodes including the BiMap. So we use standard json serialization for better human readability and simple interop with future systems.

Avoid repeated ids in the case of deleting a node

