### PR TITLE
fix analysis from history

### DIFF
--- a/apis/src/components/organisms/analysis/tree.rs
+++ b/apis/src/components/organisms/analysis/tree.rs
@@ -48,12 +48,14 @@ impl AnalysisTree {
             previous = Some(new_id);
         }
         let current_node = previous.and_then(|p| tree.get_node_by_id(&p));
-        Some(Self {
+        let mut tree = Self {
             current_node,
             tree,
             hashes,
             game_type: gs.state.game_type,
-        })
+        };
+        tree.update_node(gs.history_turn.unwrap_or(0)as i32);
+        Some(tree)
     }
 
     pub fn update_node(&mut self, node_id: i32) -> Option<()> {

--- a/apis/src/providers/game_state.rs
+++ b/apis/src/providers/game_state.rs
@@ -47,6 +47,7 @@ impl GameStateSignal {
 
     pub fn do_analysis(&mut self) {
         self.signal.update(|s| {
+            s.view = View::Game;
             s.game_id = None;
             s.state.game_status = GameStatus::InProgress;
             s.black_id = None;


### PR DESCRIPTION
Fixes a bug where analysis doesnt load the game correctly if entering from a point it history other than the last (currently only possible on mobile)