### PR TITLE
Updates to leptos use 0.11, changes to msgpack encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -424,6 +424,7 @@ dependencies = [
  "bimap",
  "cfg-if",
  "chrono",
+ "codee",
  "console_error_panic_hook",
  "cookie 0.18.1",
  "db",
@@ -713,9 +714,9 @@ checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 dependencies = [
  "jobserver",
  "libc",
@@ -777,6 +778,15 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "codee"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af40247be877a1e3353fb406aa27ab3ef4bd3ff18cef91e75e667bfa3fde701d"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -1929,9 +1939,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leptix_primitives"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb1c55c1e0403f008c8f82362e4e247034552d64cf641f51d12a2c46d391bf7"
+checksum = "d3918fee422cf80296a97f3c10a628419835eaa149e5da96d8205e82dbe32240"
 dependencies = [
  "derive_more",
  "itertools 0.12.1",
@@ -1966,12 +1976,13 @@ dependencies = [
 
 [[package]]
 name = "leptos-use"
-version = "0.10.10"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3272d90b77cdbb99e9060f90eb6f5738e56128b2f912db57a50efb006a26e262"
+checksum = "118fc5800f2ad58888ee849f0c133d9d62a63244c99f6e67170bf3558241b562"
 dependencies = [
  "async-trait",
  "cfg-if",
+ "codee",
  "cookie 0.18.1",
  "default-struct-builder",
  "futures-util",
@@ -2622,9 +2633,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+dependencies = [
+ "zerocopy 0.6.6",
+]
 
 [[package]]
 name = "pq-sys"
@@ -3933,11 +3947,32 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af40247be877a1e3353fb406aa27ab3ef4bd3ff18cef91e75e667bfa3fde701d"
 dependencies = [
+ "rmp-serde",
+ "serde",
  "thiserror",
 ]
 
@@ -2829,6 +2831,28 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "rstml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1" }
 cfg-if = "1.0.0"
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
-codee = "0.1.2"
+codee = { version = "0.1.2", features = ["msgpack_serde"] }
 regex = "1.10"
 http = "1.1.0"
 log = "0.4.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ opt-level = 'z'
 
 [workspace.dependencies]
 leptos = { version = "0.6" , features = ["nightly"] }
-leptos-use = { version = "0.10" }
+leptos-use = { version = "0.11" }
 leptos_meta =  { version = "0.6" , features = ["nightly"] }
 leptos_router =  { version = "0.6" , features = ["nightly"] }
 leptos_actix =  { version = "0.6" }
@@ -32,6 +32,7 @@ serde_json = { version = "1" }
 cfg-if = "1.0.0"
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
+codee = "0.1.2"
 regex = "1.10"
 http = "1.1.0"
 log = "0.4.22"
@@ -56,7 +57,7 @@ cookie = "0.18"
 skillratings = "0.27"
 chrono = { version = "0.4", features = ["serde"] }
 itertools = "0.13.0"
-leptix_primitives = { version = "0.2.0" }
+leptix_primitives = { version = "0.2" }
 tree-ds = {version = "0.1.5", features = ["serde", "compact_serde"] }
 bimap = {version = "0.6.3", features = ["serde"] }
 # Defines a size-optimized profile for the WASM bundle in release mode

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -17,6 +17,7 @@ actix = { workspace = true, optional = true }
 argon2 = { workspace = true, optional = true }
 cfg-if = { workspace = true }
 chrono = { workspace = true }
+codee ={ workspace = true }
 console_error_panic_hook = { workspace = true }
 cookie = { workspace = true }
 db = { path = "../db", optional = true  }

--- a/apis/src/common/mod.rs
+++ b/apis/src/common/mod.rs
@@ -24,8 +24,8 @@ pub use move_info::MoveInfo;
 pub use piece_type::PieceType;
 pub use rating_change_info::RatingChangeInfo;
 pub use server_result::{
-    ChallengeUpdate, ExternalServerError, GameActionResponse, GameUpdate, ServerMessage,
-    ServerResult, TournamentUpdate, UserStatus, UserUpdate,
+    ChallengeUpdate, CommonMessage, ExternalServerError, GameActionResponse, GameUpdate,
+    ServerMessage, ServerResult, TournamentUpdate, UserStatus, UserUpdate,
 };
 pub use svg_pos::SvgPos;
 pub use time_signals::TimeSignals;

--- a/apis/src/common/server_result.rs
+++ b/apis/src/common/server_result.rs
@@ -1,4 +1,5 @@
 use super::game_reaction::GameReaction;
+use super::ClientRequest;
 use crate::responses::{
     ChallengeResponse, GameResponse, HeartbeatResponse, TournamentResponse, UserResponse,
 };
@@ -15,6 +16,11 @@ pub enum ServerResult {
     Err(ExternalServerError),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CommonMessage {
+    Server(ServerResult),
+    Client(ClientRequest),
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExternalServerError {
     pub user_id: Uuid,

--- a/apis/src/components/organisms/analysis/tree.rs
+++ b/apis/src/components/organisms/analysis/tree.rs
@@ -54,7 +54,7 @@ impl AnalysisTree {
             hashes,
             game_type: gs.state.game_type,
         };
-        tree.update_node(gs.history_turn.unwrap_or(0)as i32);
+        tree.update_node(gs.history_turn.unwrap_or(0) as i32);
         Some(tree)
     }
 

--- a/apis/src/jobs/tournament_start.rs
+++ b/apis/src/jobs/tournament_start.rs
@@ -87,14 +87,14 @@ pub fn run(pool: DbPool, ws_server: Data<Addr<WsServer>>) {
                                     let serialized = CommonMessage::Server(ServerResult::Ok(
                                         Box::new(message.message),
                                     ));
-                                    let serialized = MsgpackSerdeCodec::encode(&serialized)
-                                        .expect("Failed to serialize a server message");
-                                    let cam = ClientActorMessage {
-                                        destination: message.destination,
-                                        serialized,
-                                        from: None,
+                                    if let Ok(serialized) = MsgpackSerdeCodec::encode(&serialized) {
+                                        let cam = ClientActorMessage {
+                                            destination: message.destination,
+                                            serialized,
+                                            from: None,
+                                        };
+                                        ws_server.do_send(cam);
                                     };
-                                    ws_server.do_send(cam);
                                 }
                             }
                             Ok(())

--- a/apis/src/providers/api_requests.rs
+++ b/apis/src/providers/api_requests.rs
@@ -30,8 +30,7 @@ impl ApiRequests {
             game_id: game_id.clone(),
             action: GameAction::Turn(turn),
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
         let mut games = expect_context::<GamesSignal>();
         // TODO: fix this so that it just removes from next_games games.remove_from_next_games(&game_id);
         games.own_games_remove(&game_id);
@@ -39,8 +38,7 @@ impl ApiRequests {
 
     pub fn pong(&self, nonce: u64) {
         let msg = ClientRequest::Pong(nonce);
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn game_control(&self, game_id: GameId, gc: GameControl) {
@@ -48,8 +46,7 @@ impl ApiRequests {
             game_id,
             action: GameAction::Control(gc),
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn tournament_game_start(&self, game_id: GameId) {
@@ -57,14 +54,12 @@ impl ApiRequests {
             game_id,
             action: GameAction::Start,
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn tournament_abandon(&self, tournament_id: TournamentId) {
         let msg = ClientRequest::Tournament(TournamentAction::Abandon(tournament_id));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn tournament_adjudicate_game_result(
@@ -74,20 +69,17 @@ impl ApiRequests {
     ) {
         let msg =
             ClientRequest::Tournament(TournamentAction::AdjudicateResult(game_id, new_result));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn chat(&self, message: &ChatMessageContainer) {
         let msg = ClientRequest::Chat(message.to_owned());
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn tournament(&self, action: TournamentAction) {
         let msg = ClientRequest::Tournament(action.to_owned());
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn game_check_time(&self, game_id: &GameId) {
@@ -95,8 +87,7 @@ impl ApiRequests {
             game_id: game_id.clone(),
             action: GameAction::CheckTime,
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn join(&self, game_id: GameId) {
@@ -104,8 +95,7 @@ impl ApiRequests {
             game_id,
             action: GameAction::Join,
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn challenge(&self, challenge_action: ChallengeAction) {
@@ -130,34 +120,29 @@ impl ApiRequests {
         };
         if let Some(challenge_action) = challenge_action {
             let msg = ClientRequest::Challenge(challenge_action);
-            self.websocket
-                .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+            self.websocket.send(&msg);
         }
     }
 
     pub fn challenge_cancel(&self, challenger_id: ChallengeId) {
         let msg = ClientRequest::Challenge(ChallengeAction::Delete(challenger_id));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn challenge_accept(&self, challenger_id: ChallengeId) {
         let msg = ClientRequest::Challenge(ChallengeAction::Accept(challenger_id));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn challenge_get(&self, challenger_id: ChallengeId) {
         let msg = ClientRequest::Challenge(ChallengeAction::Get(challenger_id));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn search_user(&self, pattern: String) {
         if !pattern.is_empty() {
             let msg = ClientRequest::UserSearch(pattern);
-            self.websocket
-                .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+            self.websocket.send(&msg);
         }
     }
 }

--- a/apis/src/providers/websocket/context.rs
+++ b/apis/src/providers/websocket/context.rs
@@ -1,15 +1,12 @@
+use super::response_handler::handle_response;
 use crate::functions::hostname::hostname_and_port;
-
+use codee::string::FromToStringCodec;
 use lazy_static::lazy_static;
 use leptos::*;
-
 use leptos_use::core::ConnectionReadyState;
 use leptos_use::*;
 use regex::Regex;
-
 use std::rc::Rc;
-
-use super::response_handler::handle_response;
 
 lazy_static! {
     static ref NANOID: Regex =
@@ -19,7 +16,7 @@ lazy_static! {
 #[derive(Clone)]
 pub struct WebsocketContext {
     pub message: Signal<Option<String>>,
-    send: Rc<dyn Fn(&str)>,
+    send: Rc<dyn Fn(&String)>,
     pub ready_state: Signal<ConnectionReadyState>,
     open: Rc<dyn Fn()>,
     close: Rc<dyn Fn()>,
@@ -28,7 +25,7 @@ pub struct WebsocketContext {
 impl WebsocketContext {
     pub fn new(
         message: Signal<Option<String>>,
-        send: Rc<dyn Fn(&str)>,
+        send: Rc<dyn Fn(&String)>,
         ready_state: Signal<ConnectionReadyState>,
         open: Rc<dyn Fn()>,
         close: Rc<dyn Fn()>,
@@ -44,7 +41,7 @@ impl WebsocketContext {
 
     #[inline(always)]
     pub fn send(&self, message: &str) {
-        (self.send)(message)
+        (self.send)(&message.to_string())
     }
 
     #[inline(always)]
@@ -60,7 +57,7 @@ impl WebsocketContext {
     }
 }
 
-fn on_message_callback(m: String) {
+fn on_message_callback(m: &String) {
     handle_response(m);
 }
 
@@ -81,14 +78,14 @@ fn fix_wss(url: &str) -> String {
 pub fn provide_websocket(url: &str) {
     let url = fix_wss(url);
     //log!("Establishing new websocket connection");
-    let UseWebsocketReturn {
+    let UseWebSocketReturn {
         message,
         send,
         ready_state,
         open,
         close,
         ..
-    } = use_websocket_with_options(
+    } = use_websocket_with_options::<String, FromToStringCodec>(
         &url,
         UseWebSocketOptions::default()
             .on_message(on_message_callback)

--- a/apis/src/providers/websocket/response_handler.rs
+++ b/apis/src/providers/websocket/response_handler.rs
@@ -9,7 +9,7 @@ use super::{
     user_search::handle::handle_user_search, user_status::handle::handle_user_status,
 };
 
-pub fn handle_response(m: String) {
+pub fn handle_response(m: &String) {
     batch(move || match serde_json::from_str::<ServerResult>(&m) {
         Ok(result) => match result {
             ServerResult::Ok(message) => match *message {

--- a/apis/src/providers/websocket/response_handler.rs
+++ b/apis/src/providers/websocket/response_handler.rs
@@ -1,4 +1,4 @@
-use crate::common::{ServerMessage::*, ServerResult};
+use crate::common::{CommonMessage, ServerMessage::*, ServerResult};
 
 use leptos::logging::log;
 use leptos::*;
@@ -9,10 +9,10 @@ use super::{
     user_search::handle::handle_user_search, user_status::handle::handle_user_status,
 };
 
-pub fn handle_response(m: &String) {
-    batch(move || match serde_json::from_str::<ServerResult>(&m) {
-        Ok(result) => match result {
-            ServerResult::Ok(message) => match *message {
+pub fn handle_response(m: &CommonMessage) {
+    batch(move || match m {
+        CommonMessage::Server(result) => match result {
+            ServerResult::Ok(message) => match *message.clone() {
                 Ping { value, nonce } => handle_ping(nonce, value),
                 UserStatus(user_update) => handle_user_status(user_update),
                 Game(game_update) => handle_game(*game_update),
@@ -26,6 +26,8 @@ pub fn handle_response(m: &String) {
             },
             ServerResult::Err(e) => log!("Got error from server: {e}"),
         },
-        Err(e) => log!("Can't parse: {m}, error is: {e}"),
+        CommonMessage::Client(request) => {
+            log!("Got a client request: {request:?}")
+        }
     });
 }

--- a/apis/src/websockets/messages.rs
+++ b/apis/src/websockets/messages.rs
@@ -5,7 +5,7 @@ use super::internal_server_message::MessageDestination;
 
 #[derive(Message, Debug)]
 #[rtype(result = "()")]
-pub struct WsMessage(pub String);
+pub struct WsMessage(pub Vec<u8>);
 
 #[derive(Message, Debug)]
 #[rtype(result = "()")]
@@ -38,11 +38,11 @@ pub struct Ping {}
 pub struct ClientActorMessage {
     pub destination: MessageDestination,
     pub from: Option<Uuid>,
-    pub serialized: String, // the serialized message
+    pub serialized: Vec<u8>, // the serialized message
 }
 
 impl ClientActorMessage {
-    pub fn new(from: Option<Uuid>, destination: MessageDestination, serialized: &str) -> Self {
+    pub fn new(from: Option<Uuid>, destination: MessageDestination, serialized: &Vec<u8>) -> Self {
         Self {
             from,
             destination,

--- a/apis/src/websockets/ws_connection.rs
+++ b/apis/src/websockets/ws_connection.rs
@@ -173,14 +173,14 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsConnection {
                                     let serialized = CommonMessage::Server(ServerResult::Ok(
                                         Box::new(message.message),
                                     ));
-                                    let serialized = MsgpackSerdeCodec::encode(&serialized)
-                                        .expect("Failed to serialize a server message");
-                                    let cam = ClientActorMessage {
-                                        destination: message.destination,
-                                        serialized,
-                                        from: Some(user_id),
+                                    if let Ok(serialized) = MsgpackSerdeCodec::encode(&serialized) {
+                                        let cam = ClientActorMessage {
+                                            destination: message.destination,
+                                            serialized,
+                                            from: Some(user_id),
+                                        };
+                                        lobby.do_send(cam);
                                     };
-                                    lobby.do_send(cam);
                                 }
                             }
                             Err(err) => {
@@ -200,14 +200,14 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsConnection {
                                     status_code: http::StatusCode::NOT_IMPLEMENTED,
                                 });
                                 let serialized = CommonMessage::Server(message);
-                                let serialized = MsgpackSerdeCodec::encode(&serialized)
-                                    .expect("Failed to serialize a server message");
-                                let cam = ClientActorMessage {
-                                    destination: MessageDestination::User(user_id),
-                                    serialized,
-                                    from: Some(user_id),
+                                if let Ok(serialized) = MsgpackSerdeCodec::encode(&serialized) {
+                                    let cam = ClientActorMessage {
+                                        destination: MessageDestination::User(user_id),
+                                        serialized,
+                                        from: Some(user_id),
+                                    };
+                                    lobby.do_send(cam);
                                 };
-                                lobby.do_send(cam);
                             }
                         }
                     };

--- a/apis/src/websockets/ws_server.rs
+++ b/apis/src/websockets/ws_server.rs
@@ -3,8 +3,8 @@ use super::{internal_server_message::MessageDestination, messages::Ping};
 use crate::ping::pings::Pings;
 use crate::{
     common::{
-        ChallengeUpdate, GameUpdate, ServerMessage, ServerResult, TournamentUpdate, UserStatus,
-        UserUpdate,
+        ChallengeUpdate, CommonMessage, GameUpdate, ServerMessage, ServerResult, TournamentUpdate,
+        UserStatus, UserUpdate,
     },
     responses::{
         ChallengeResponse, GameResponse, HeartbeatResponse, TournamentResponse, UserResponse,
@@ -16,6 +16,8 @@ use actix::{
     AsyncContext, WrapFuture,
 };
 use actix_web::web::Data;
+use codee::binary::MsgpackSerdeCodec;
+use codee::Encoder;
 use db_lib::{
     get_conn,
     models::{Challenge, Game, Tournament, TournamentInvitation, User},
@@ -53,7 +55,7 @@ impl WsServer {
 }
 
 impl WsServer {
-    fn send_message(&self, message: &str, id_to: &Uuid) {
+    fn send_message(&self, message: &Vec<u8>, id_to: &Uuid) {
         if let Some(sockets) = self.sessions.get(id_to) {
             for socket in sockets {
                 socket.do_send(WsMessage(message.to_owned()));
@@ -78,8 +80,9 @@ impl Handler<Ping> for WsServer {
                 nonce,
                 value: self.pings.value(*user_id),
             }));
-            let serialized =
-                serde_json::to_string(&message).expect("Failed to serialize a server message");
+            let serialized = CommonMessage::Server(message);
+            let serialized = MsgpackSerdeCodec::encode(&serialized)
+                .expect("Failed to serialize a server message");
             self.send_message(&serialized, user_id);
         }
     }
@@ -110,7 +113,8 @@ impl Handler<GameHB> for WsServer {
                                 let message = ServerResult::Ok(Box::new(ServerMessage::Game(
                                     Box::new(GameUpdate::Heartbeat(hb)),
                                 )));
-                                let serialized = serde_json::to_string(&message)
+                                let serialized = CommonMessage::Server(message);
+                                let serialized = MsgpackSerdeCodec::encode(&serialized)
                                     .expect("Failed to serialize a server message");
                                 for user_id in user_ids {
                                     if let Some(sockets) = sessions.get(&user_id) {
@@ -161,8 +165,9 @@ impl Handler<Disconnect> for WsServer {
                 user: None,
                 username: msg.username,
             })));
-            let serialized =
-                serde_json::to_string(&message).expect("Failed to serialize a server message");
+            let serialized = CommonMessage::Server(message);
+            let serialized = MsgpackSerdeCodec::encode(&serialized)
+                .expect("Failed to serialize a server message");
             let game_id = GameId(self.id.clone());
             if let Some(ws_server) = self.games_users.get_mut(&game_id) {
                 ws_server.remove(&msg.user_id);
@@ -208,7 +213,8 @@ impl Handler<Connect> for WsServer {
                                 user: Some(user_response.clone()),
                                 username: user_response.username,
                             })));
-                        let serialized = serde_json::to_string(&message)
+                        let serialized = CommonMessage::Server(message);
+                        let serialized = MsgpackSerdeCodec::encode(&serialized)
                             .expect("Failed to serialize a server message");
                         let cam = ClientActorMessage {
                             destination: MessageDestination::User(user_id),
@@ -227,7 +233,8 @@ impl Handler<Connect> for WsServer {
                                 user: Some(user_response),
                                 username: msg.username,
                             })));
-                        let serialized = serde_json::to_string(&message)
+                        let serialized = CommonMessage::Server(message);
+                        let serialized = MsgpackSerdeCodec::encode(&serialized)
                             .expect("Failed to serialize a server message");
                         // TODO: one needs to be a game::join to everyone in the game, the other one just to the
                         // ws_server that the user came online
@@ -270,7 +277,8 @@ impl Handler<Connect> for WsServer {
                             let message = ServerResult::Ok(Box::new(ServerMessage::Game(
                                 Box::new(GameUpdate::Urgent(games)),
                             )));
-                            let serialized = serde_json::to_string(&message)
+                            let serialized = CommonMessage::Server(message);
+                            let serialized = MsgpackSerdeCodec::encode(&serialized)
                                 .expect("Failed to serialize a server message");
                             let cam = ClientActorMessage {
                                 destination: MessageDestination::User(user_id),
@@ -292,7 +300,8 @@ impl Handler<Connect> for WsServer {
                                 let message = ServerResult::Ok(Box::new(
                                     ServerMessage::Tournament(TournamentUpdate::Invited(response)),
                                 ));
-                                let serialized = serde_json::to_string(&message)
+                                let serialized = CommonMessage::Server(message);
+                                let serialized = MsgpackSerdeCodec::encode(&serialized)
                                     .expect("Failed to serialize a server message");
                                 let cam = ClientActorMessage {
                                     destination: MessageDestination::User(user_id),
@@ -338,7 +347,9 @@ impl Handler<Connect> for WsServer {
                     let message = ServerResult::Ok(Box::new(ServerMessage::Challenge(
                         ChallengeUpdate::Challenges(responses),
                     )));
-                    serde_json::to_string(&message).expect("Failed to serialize a server message")
+                    let message = CommonMessage::Server(message);
+                    MsgpackSerdeCodec::encode(&message)
+                        .expect("Failed to serialize a server message")
                 } else {
                     let mut responses = Vec::new();
                     if let Ok(challenges) = Challenge::get_public(&mut conn).await {
@@ -353,7 +364,9 @@ impl Handler<Connect> for WsServer {
                     let message = ServerResult::Ok(Box::new(ServerMessage::Challenge(
                         ChallengeUpdate::Challenges(responses),
                     )));
-                    serde_json::to_string(&message).expect("Failed to serialize a server message")
+                    let message = CommonMessage::Server(message);
+                    MsgpackSerdeCodec::encode(&message)
+                        .expect("Failed to serialize a server message")
                 };
                 let cam = ClientActorMessage {
                     destination: MessageDestination::User(user_id),


### PR DESCRIPTION
Upgrades to leptos_use 0.11, this allows us to use codecs for our ws messages. 

Wip: Need to use better types on the ws messages, the current changes are just following compiler suggestions to get it working again after the breaking changes introduced by leptos_use