### PR TITLE
use messagepack codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af40247be877a1e3353fb406aa27ab3ef4bd3ff18cef91e75e667bfa3fde701d"
 dependencies = [
+ "rmp-serde",
+ "serde",
  "thiserror",
 ]
 
@@ -2829,6 +2831,28 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "rstml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { version = "1" }
 cfg-if = "1.0.0"
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
-codee = "0.1.2"
+codee = { version = "0.1.2", features = ["msgpack_serde"] }
 regex = "1.10"
 http = "1.1.0"
 log = "0.4.22"

--- a/apis/src/common/mod.rs
+++ b/apis/src/common/mod.rs
@@ -24,8 +24,8 @@ pub use move_info::MoveInfo;
 pub use piece_type::PieceType;
 pub use rating_change_info::RatingChangeInfo;
 pub use server_result::{
-    ChallengeUpdate, ExternalServerError, GameActionResponse, GameUpdate, ServerMessage,
-    ServerResult, TournamentUpdate, UserStatus, UserUpdate,
+    ChallengeUpdate, CommonMessage, ExternalServerError, GameActionResponse, GameUpdate,
+    ServerMessage, ServerResult, TournamentUpdate, UserStatus, UserUpdate,
 };
 pub use svg_pos::SvgPos;
 pub use time_signals::TimeSignals;

--- a/apis/src/common/server_result.rs
+++ b/apis/src/common/server_result.rs
@@ -1,4 +1,5 @@
 use super::game_reaction::GameReaction;
+use super::ClientRequest;
 use crate::responses::{
     ChallengeResponse, GameResponse, HeartbeatResponse, TournamentResponse, UserResponse,
 };
@@ -15,6 +16,11 @@ pub enum ServerResult {
     Err(ExternalServerError),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CommonMessage {
+    Server(ServerResult),
+    Client(ClientRequest),
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExternalServerError {
     pub user_id: Uuid,

--- a/apis/src/components/organisms/analysis/tree.rs
+++ b/apis/src/components/organisms/analysis/tree.rs
@@ -54,7 +54,7 @@ impl AnalysisTree {
             hashes,
             game_type: gs.state.game_type,
         };
-        tree.update_node(gs.history_turn.unwrap_or(0)as i32);
+        tree.update_node(gs.history_turn.unwrap_or(0) as i32);
         Some(tree)
     }
 

--- a/apis/src/jobs/tournament_start.rs
+++ b/apis/src/jobs/tournament_start.rs
@@ -7,6 +7,8 @@ use crate::websockets::messages::ClientActorMessage;
 use crate::websockets::ws_server::WsServer;
 use actix::Addr;
 use actix_web::web::Data;
+use codee::binary::MsgpackSerdeCodec;
+use codee::Encoder;
 use db_lib::{get_conn, models::Tournament, DbPool};
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::AsyncConnection;
@@ -84,6 +86,8 @@ pub fn run(pool: DbPool, ws_server: Data<Addr<WsServer>>) {
                                     let serialized = serde_json::to_string(&ServerResult::Ok(
                                         Box::new(message.message),
                                     ))
+                                    .expect("Failed to serialize a server message");
+                                    let serialized = MsgpackSerdeCodec::encode(&serialized)
                                     .expect("Failed to serialize a server message");
                                     let cam = ClientActorMessage {
                                         destination: message.destination,

--- a/apis/src/jobs/tournament_start.rs
+++ b/apis/src/jobs/tournament_start.rs
@@ -1,5 +1,6 @@
 use crate::common::{
-    GameActionResponse, GameReaction, GameUpdate, ServerMessage, ServerResult, TournamentUpdate,
+    CommonMessage, GameActionResponse, GameReaction, GameUpdate, ServerMessage, ServerResult,
+    TournamentUpdate,
 };
 use crate::responses::{GameResponse, TournamentResponse};
 use crate::websockets::internal_server_message::{InternalServerMessage, MessageDestination};
@@ -83,12 +84,11 @@ pub fn run(pool: DbPool, ws_server: Data<Addr<WsServer>>) {
                                     }
                                 }
                                 for message in messages {
-                                    let serialized = serde_json::to_string(&ServerResult::Ok(
+                                    let serialized = CommonMessage::Server(ServerResult::Ok(
                                         Box::new(message.message),
-                                    ))
-                                    .expect("Failed to serialize a server message");
+                                    ));
                                     let serialized = MsgpackSerdeCodec::encode(&serialized)
-                                    .expect("Failed to serialize a server message");
+                                        .expect("Failed to serialize a server message");
                                     let cam = ClientActorMessage {
                                         destination: message.destination,
                                         serialized,

--- a/apis/src/providers/api_requests.rs
+++ b/apis/src/providers/api_requests.rs
@@ -30,8 +30,7 @@ impl ApiRequests {
             game_id: game_id.clone(),
             action: GameAction::Turn(turn),
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
         let mut games = expect_context::<GamesSignal>();
         // TODO: fix this so that it just removes from next_games games.remove_from_next_games(&game_id);
         games.own_games_remove(&game_id);
@@ -39,8 +38,7 @@ impl ApiRequests {
 
     pub fn pong(&self, nonce: u64) {
         let msg = ClientRequest::Pong(nonce);
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn game_control(&self, game_id: GameId, gc: GameControl) {
@@ -48,8 +46,7 @@ impl ApiRequests {
             game_id,
             action: GameAction::Control(gc),
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn tournament_game_start(&self, game_id: GameId) {
@@ -57,14 +54,12 @@ impl ApiRequests {
             game_id,
             action: GameAction::Start,
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn tournament_abandon(&self, tournament_id: TournamentId) {
         let msg = ClientRequest::Tournament(TournamentAction::Abandon(tournament_id));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn tournament_adjudicate_game_result(
@@ -74,20 +69,17 @@ impl ApiRequests {
     ) {
         let msg =
             ClientRequest::Tournament(TournamentAction::AdjudicateResult(game_id, new_result));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn chat(&self, message: &ChatMessageContainer) {
         let msg = ClientRequest::Chat(message.to_owned());
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn tournament(&self, action: TournamentAction) {
         let msg = ClientRequest::Tournament(action.to_owned());
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn game_check_time(&self, game_id: &GameId) {
@@ -95,8 +87,7 @@ impl ApiRequests {
             game_id: game_id.clone(),
             action: GameAction::CheckTime,
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn join(&self, game_id: GameId) {
@@ -104,8 +95,7 @@ impl ApiRequests {
             game_id,
             action: GameAction::Join,
         };
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn challenge(&self, challenge_action: ChallengeAction) {
@@ -130,34 +120,29 @@ impl ApiRequests {
         };
         if let Some(challenge_action) = challenge_action {
             let msg = ClientRequest::Challenge(challenge_action);
-            self.websocket
-                .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+            self.websocket.send(&msg);
         }
     }
 
     pub fn challenge_cancel(&self, challenger_id: ChallengeId) {
         let msg = ClientRequest::Challenge(ChallengeAction::Delete(challenger_id));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn challenge_accept(&self, challenger_id: ChallengeId) {
         let msg = ClientRequest::Challenge(ChallengeAction::Accept(challenger_id));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn challenge_get(&self, challenger_id: ChallengeId) {
         let msg = ClientRequest::Challenge(ChallengeAction::Get(challenger_id));
-        self.websocket
-            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        self.websocket.send(&msg);
     }
 
     pub fn search_user(&self, pattern: String) {
         if !pattern.is_empty() {
             let msg = ClientRequest::UserSearch(pattern);
-            self.websocket
-                .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+            self.websocket.send(&msg);
         }
     }
 }

--- a/apis/src/providers/websocket/context.rs
+++ b/apis/src/providers/websocket/context.rs
@@ -1,12 +1,12 @@
 use super::response_handler::handle_response;
 use crate::functions::hostname::hostname_and_port;
-use codee::string::FromToStringCodec;
 use lazy_static::lazy_static;
 use leptos::*;
 use leptos_use::core::ConnectionReadyState;
 use leptos_use::*;
 use regex::Regex;
 use std::rc::Rc;
+use codee::binary::MsgpackSerdeCodec;
 
 lazy_static! {
     static ref NANOID: Regex =
@@ -85,7 +85,7 @@ pub fn provide_websocket(url: &str) {
         open,
         close,
         ..
-    } = use_websocket_with_options::<String, FromToStringCodec>(
+    } = use_websocket_with_options::<String, MsgpackSerdeCodec>(
         &url,
         UseWebSocketOptions::default()
             .on_message(on_message_callback)

--- a/apis/src/providers/websocket/context.rs
+++ b/apis/src/providers/websocket/context.rs
@@ -1,12 +1,13 @@
 use super::response_handler::handle_response;
+use crate::common::{ClientRequest, CommonMessage};
 use crate::functions::hostname::hostname_and_port;
+use codee::binary::MsgpackSerdeCodec;
 use lazy_static::lazy_static;
 use leptos::*;
 use leptos_use::core::ConnectionReadyState;
 use leptos_use::*;
 use regex::Regex;
 use std::rc::Rc;
-use codee::binary::MsgpackSerdeCodec;
 
 lazy_static! {
     static ref NANOID: Regex =
@@ -15,8 +16,8 @@ lazy_static! {
 
 #[derive(Clone)]
 pub struct WebsocketContext {
-    pub message: Signal<Option<String>>,
-    send: Rc<dyn Fn(&String)>,
+    pub message: Signal<Option<CommonMessage>>,
+    send: Rc<dyn Fn(&CommonMessage)>,
     pub ready_state: Signal<ConnectionReadyState>,
     open: Rc<dyn Fn()>,
     close: Rc<dyn Fn()>,
@@ -24,8 +25,8 @@ pub struct WebsocketContext {
 
 impl WebsocketContext {
     pub fn new(
-        message: Signal<Option<String>>,
-        send: Rc<dyn Fn(&String)>,
+        message: Signal<Option<CommonMessage>>,
+        send: Rc<dyn Fn(&CommonMessage)>,
         ready_state: Signal<ConnectionReadyState>,
         open: Rc<dyn Fn()>,
         close: Rc<dyn Fn()>,
@@ -40,8 +41,9 @@ impl WebsocketContext {
     }
 
     #[inline(always)]
-    pub fn send(&self, message: &str) {
-        (self.send)(&message.to_string())
+    pub fn send(&self, message: &ClientRequest) {
+        let message = CommonMessage::Client(message.clone());
+        (self.send)(&message)
     }
 
     #[inline(always)]
@@ -57,7 +59,7 @@ impl WebsocketContext {
     }
 }
 
-fn on_message_callback(m: &String) {
+fn on_message_callback(m: &CommonMessage) {
     handle_response(m);
 }
 
@@ -85,7 +87,7 @@ pub fn provide_websocket(url: &str) {
         open,
         close,
         ..
-    } = use_websocket_with_options::<String, MsgpackSerdeCodec>(
+    } = use_websocket_with_options::<CommonMessage, MsgpackSerdeCodec>(
         &url,
         UseWebSocketOptions::default()
             .on_message(on_message_callback)

--- a/apis/src/providers/websocket/response_handler.rs
+++ b/apis/src/providers/websocket/response_handler.rs
@@ -10,7 +10,7 @@ use super::{
 };
 
 pub fn handle_response(m: &String) {
-    batch(move || match serde_json::from_str::<ServerResult>(&m) {
+    batch(move || match serde_json::from_str::<ServerResult>(m) {
         Ok(result) => match result {
             ServerResult::Ok(message) => match *message {
                 Ping { value, nonce } => handle_ping(nonce, value),

--- a/apis/src/providers/websocket/response_handler.rs
+++ b/apis/src/providers/websocket/response_handler.rs
@@ -1,4 +1,4 @@
-use crate::common::{ServerMessage::*, ServerResult};
+use crate::common::{CommonMessage, ServerMessage::*, ServerResult};
 
 use leptos::logging::log;
 use leptos::*;
@@ -9,10 +9,10 @@ use super::{
     user_search::handle::handle_user_search, user_status::handle::handle_user_status,
 };
 
-pub fn handle_response(m: &String) {
-    batch(move || match serde_json::from_str::<ServerResult>(m) {
-        Ok(result) => match result {
-            ServerResult::Ok(message) => match *message {
+pub fn handle_response(m: &CommonMessage) {
+    batch(move || match m {
+        CommonMessage::Server(result) => match result {
+            ServerResult::Ok(message) => match *message.clone() {
                 Ping { value, nonce } => handle_ping(nonce, value),
                 UserStatus(user_update) => handle_user_status(user_update),
                 Game(game_update) => handle_game(*game_update),
@@ -26,6 +26,8 @@ pub fn handle_response(m: &String) {
             },
             ServerResult::Err(e) => log!("Got error from server: {e}"),
         },
-        Err(e) => log!("Can't parse: {m}, error is: {e}"),
+        CommonMessage::Client(request) => {
+            log!("Got a client request: {request:?}")
+        }
     });
 }

--- a/apis/src/websockets/messages.rs
+++ b/apis/src/websockets/messages.rs
@@ -5,7 +5,7 @@ use super::internal_server_message::MessageDestination;
 
 #[derive(Message, Debug)]
 #[rtype(result = "()")]
-pub struct WsMessage(pub String);
+pub struct WsMessage(pub Vec<u8>);
 
 #[derive(Message, Debug)]
 #[rtype(result = "()")]
@@ -38,11 +38,11 @@ pub struct Ping {}
 pub struct ClientActorMessage {
     pub destination: MessageDestination,
     pub from: Option<Uuid>,
-    pub serialized: String, // the serialized message
+    pub serialized: Vec<u8>, // the serialized message
 }
 
 impl ClientActorMessage {
-    pub fn new(from: Option<Uuid>, destination: MessageDestination, serialized: &str) -> Self {
+    pub fn new(from: Option<Uuid>, destination: MessageDestination, serialized: &Vec<u8>) -> Self {
         Self {
             from,
             destination,


### PR DESCRIPTION
This change is useless on its own. The main point is to show that using a binary encoding works correctly.

Also, once the String type on the socket is replaced by some nicer type (and hence the underlying conversion to and from JSON is avoided) messages would become substantially smaller