### PR TITLE
add history controls to chat, add analysis button to history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "icondata"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e75326892b8f4aa213dae3fef9214b9bb5a865a5267ac2143393b72cd78ffa"
+checksum = "18db9eec46b6c870bf84281dd8065fb207b23a9c1c0cb367c49a919a61a38dec"
 dependencies = [
  "icondata_ai",
  "icondata_bi",
@@ -1920,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1941,9 +1952,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leptix_primitives"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3918fee422cf80296a97f3c10a628419835eaa149e5da96d8205e82dbe32240"
+checksum = "ca26deee13563c00d01814228f46afac57ea8858e912ed3675c0e899db9529ce"
 dependencies = [
  "derive_more",
  "itertools 0.12.1",
@@ -1978,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "leptos-use"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac79c02d0e2998569116aa36d26fd00bfa8cadbe8cb630eb771b4d1676412a16"
+checksum = "268b9df23d8c68ed0518c39d6f0d3b99fcbe30190a6dce4a7e5f342027ab0033"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1995,6 +2006,7 @@ dependencies = [
  "leptos",
  "paste",
  "thiserror",
+ "unic-langid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3379,6 +3391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,6 +3587,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unic-langid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dd9d1e72a73b25e07123a80776aae3e7b0ec461ef94f9151eed6ec88005a44"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5422c1f65949306c99240b81de9f3f15929f5a8bfe05bb44b034cc8bf593e5"
+dependencies = [
+ "tinystr",
+]
+
+[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,19 +3732,20 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -3730,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3740,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3753,9 +3793,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
@@ -3772,9 +3812,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ opt-level = 'z'
 
 [workspace.dependencies]
 leptos = { version = "0.6" , features = ["nightly"] }
-leptos-use = { version = "0.11" }
+leptos-use = { version = "0.12" }
 leptos_meta =  { version = "0.6" , features = ["nightly"] }
 leptos_router =  { version = "0.6" , features = ["nightly"] }
 leptos_actix =  { version = "0.6" }
 leptos_icons = { version = "0.3"}
-icondata = {version = "0.3"}
+icondata = {version = "0.4"}
 actix-web = { version = "4",  features = ["macros"] }
 actix-files = { version = "0.6" }
 actix-web-actors = { version  = "4.3.0" }
@@ -40,9 +40,9 @@ simple_logger = "5.0"
 thiserror = "1"
 anyhow = "1"
 tokio = { version = "1.39.2", features = ["full"] }
-wasm-bindgen = "0.2.92"
+wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4"
-web-sys = {version = "0.3.69", features = ["AbortController", "AbortSignal", "AudioContext", "AudioBuffer", "AudioBufferSourceNode", "AudioDestinationNode", "Blob", "Clipboard", "HtmlDocument", "SvgPoint", "SvgsvgElement", "SvgGraphicsElement", "SvgRect", "SvgMatrix", "Url", "Window"] }
+web-sys = {version = "0.3.70", features = ["AbortController", "AbortSignal", "AudioContext", "AudioBuffer", "AudioBufferSourceNode", "AudioDestinationNode", "Blob", "Clipboard", "HtmlDocument", "SvgPoint", "SvgsvgElement", "SvgGraphicsElement", "SvgRect", "SvgMatrix", "Url", "Window"] }
 bb8 = { version = "0.8" }
 diesel = { version = "2.2", features = ["postgres", "chrono", "uuid", "serde_json"] }
 diesel-async = { version = "0.5", features = ["postgres", "bb8"] }

--- a/apis/src/components/molecules/challenge_row.rs
+++ b/apis/src/components/molecules/challenge_row.rs
@@ -52,8 +52,7 @@ pub fn ChallengeRow(challenge: StoredValue<ChallengeResponse>, single: bool) -> 
             .as_ref()
             .expect("window to exist")
             .navigator()
-            .clipboard()
-            .expect("to have clipboard permission");
+            .clipboard();
         let _ = clipboard.write_text(&challenge_address());
         let class_list = button_ref
             .get_untracked()

--- a/apis/src/components/molecules/history_controls.rs
+++ b/apis/src/components/molecules/history_controls.rs
@@ -1,0 +1,92 @@
+use crate::components::atoms::history_button::{HistoryButton, HistoryNavigation};
+use crate::components::organisms::reserve::{Alignment, Reserve};
+use crate::providers::game_state::GameStateSignal;
+use ev::keydown;
+use hive_lib::Color;
+use leptos::*;
+use leptos_use::{use_event_listener, use_window};
+
+#[component]
+pub fn HistoryControls(#[prop(optional)] parent: MaybeProp<NodeRef<html::Div>>) -> impl IntoView {
+    let game_state = expect_context::<GameStateSignal>();
+    let window = use_window();
+    let active = Signal::derive(move || {
+        window.as_ref().and_then(|w| {
+            w.document()
+                .expect("window to have a document")
+                .query_selector(".bg-orange-twilight")
+                .expect("to have an Element")
+        })
+    });
+    let focus = Callback::new(move |()| {
+        if let Some(elem) = active.get_untracked() {
+            elem.scroll_into_view_with_bool(false);
+        }
+    });
+    let prev_button = create_node_ref::<html::Button>();
+    let next_button = create_node_ref::<html::Button>();
+    _ = use_event_listener(document().body(), keydown, move |evt| {
+        if evt.key() == "ArrowLeft" {
+            evt.prevent_default();
+            if let Some(prev) = prev_button.get_untracked() {
+                prev.click()
+            };
+        } else if evt.key() == "ArrowRight" {
+            evt.prevent_default();
+            if let Some(next) = next_button.get_untracked() {
+                next.click()
+            };
+        }
+    });
+
+    let go_to_end = Callback::new(move |()| {
+        if let Some(parent) = parent.get() {
+            let parent = parent.get_untracked().expect("div to be loaded");
+            parent.set_scroll_top(parent.scroll_height());
+        }
+        game_state.show_history_turn(game_state.signal.get_untracked().state.turn - 1);
+    });
+    let if_last_go_to_end = Callback::new(move |()| {
+        focus(());
+        let gamestate = game_state.signal.get_untracked();
+        {
+            if let Some(turn) = gamestate.history_turn {
+                if turn == gamestate.state.turn - 1 {
+                    go_to_end(());
+                }
+            }
+        }
+    });
+    view! {
+        <div>
+            <div class="flex gap-1 min-h-0 [&>*]:grow">
+                <HistoryButton
+
+                    action=HistoryNavigation::First
+                    post_action=focus
+                />
+
+                <HistoryButton
+                    node_ref=prev_button
+                    action=HistoryNavigation::Previous
+                    post_action=focus
+                />
+                <HistoryButton
+                    node_ref=next_button
+                    action=HistoryNavigation::Next
+                    post_action=if_last_go_to_end
+                />
+
+                <HistoryButton
+
+                    action=HistoryNavigation::Last
+                    post_action=go_to_end
+                />
+            </div>
+            <div class="flex p-2">
+                <Reserve alignment=Alignment::DoubleRow color=Color::White analysis=false/>
+                <Reserve alignment=Alignment::DoubleRow color=Color::Black analysis=false/>
+            </div>
+        </div>
+    }
+}

--- a/apis/src/components/molecules/mod.rs
+++ b/apis/src/components/molecules/mod.rs
@@ -10,6 +10,7 @@ pub mod game_previews;
 pub mod game_row;
 pub mod hamburger;
 pub mod hex_stack;
+pub mod history_controls;
 pub mod history_pieces;
 pub mod hover_ratings;
 pub mod invite_user;

--- a/apis/src/components/organisms/side_board.rs
+++ b/apis/src/components/organisms/side_board.rs
@@ -1,12 +1,15 @@
-use crate::components::organisms::reserve::ReserveContent;
 use crate::{
-    components::organisms::{chat::ChatWindow, history::History},
+    components::{
+        molecules::history_controls::HistoryControls,
+        organisms::{chat::ChatWindow, history::History, reserve::ReserveContent},
+    },
     providers::{chat::Chat, game_state::GameStateSignal},
 };
 use hive_lib::Color;
 use leptix_primitives::components::tabs::{TabsContent, TabsList, TabsRoot, TabsTrigger};
 use leptos::*;
 use shared_types::SimpleDestination;
+
 #[derive(Clone, PartialEq, Copy)]
 enum TabView {
     Reserve,
@@ -83,7 +86,8 @@ pub fn SideboardTabs(
             <TabsContent value="History" attr:class="h-full">
                 <History/>
             </TabsContent>
-            <TabsContent value="Chat" attr:class="h-[95%]">
+            <TabsContent value="Chat" attr:class="h-[68%]">
+                <HistoryControls/>
                 <ChatWindow destination=SimpleDestination::Game/>
             </TabsContent>
         </TabsRoot>

--- a/apis/src/pages/challenge_view.rs
+++ b/apis/src/pages/challenge_view.rs
@@ -35,8 +35,7 @@ pub fn ChallengeView() -> impl IntoView {
             .as_ref()
             .expect("window to exist in challenge_view")
             .navigator()
-            .clipboard()
-            .expect("to have clipboard permission");
+            .clipboard();
         let _ = clipboard.write_text(&challenge_address());
         let class_list = button_ref
             .get_untracked()

--- a/apis/src/providers/game_state.rs
+++ b/apis/src/providers/game_state.rs
@@ -165,7 +165,7 @@ impl GameStateSignal {
         self.signal.update(|s| s.set_target(position))
     }
 
-    pub fn show_history_turn(&mut self, turn: usize) {
+    pub fn show_history_turn(&self, turn: usize) {
         self.signal.update(|s| s.show_history_turn(turn))
     }
 
@@ -423,9 +423,6 @@ impl GameState {
 
     pub fn view_history(&mut self) {
         self.view = View::History;
-        if self.state.turn > 0 {
-            self.history_turn = Some(self.state.turn - 1);
-        }
     }
 
     //TODO: is this still useful for play and analysis where gamestate is untracked for the callback?
@@ -438,6 +435,9 @@ impl GameState {
 
     pub fn view_game(&mut self) {
         self.view = View::Game;
+        if self.state.turn > 0 {
+            self.history_turn = Some(self.state.turn - 1);
+        }
     }
 
     pub fn next_history_turn(&mut self) {


### PR DESCRIPTION
- add analysis button to history
- add history controls to chat
- moving from history to chat (also chat to history) now maintains history turn, moving to game goes to the last.
- Update deps

Note: removed the mutable reference in `GameStateSignal::show_history_turn` since its needed to use inside the callback and also its not required to update the signal, might be worth changing other functions of this type in a similar way, to make life simpler