### PR TITLE
Refactors game_previews, fixes text overflow

### DIFF
--- a/apis/src/components/molecules/game_row.rs
+++ b/apis/src/components/molecules/game_row.rs
@@ -96,7 +96,7 @@ pub fn GameRow(game: StoredValue<GameResponse>) -> impl IntoView {
     view! {
         <article class="flex relative px-2 py-4 mx-2 w-full h-72 duration-300 dark:odd:bg-header-twilight dark:even:bg-reserve-twilight odd:bg-odd-light even:bg-even-light hover:bg-blue-light hover:dark:bg-teal-900">
             <div class="mx-2 w-60 h-60">
-                <ThumbnailPieces game=game()/>
+                <ThumbnailPieces game/>
             </div>
             <div class="flex overflow-hidden flex-col justify-between m-2 w-full">
                 <div class="flex flex-col justify-between">
@@ -131,7 +131,7 @@ pub fn GameRow(game: StoredValue<GameResponse>) -> impl IntoView {
                         </div>
                         <br/>
                         <Show when=is_finished fallback=move || { game().white_rating() }>
-                            <RatingAndChange ratings=ratings() side=Color::White/>
+                            <RatingAndChange ratings side=Color::White/>
                         </Show>
 
                     </div>
@@ -146,7 +146,7 @@ pub fn GameRow(game: StoredValue<GameResponse>) -> impl IntoView {
                         </div>
                         <br/>
                         <Show when=is_finished fallback=move || { game().black_rating() }>
-                            <RatingAndChange ratings=ratings() side=Color::Black/>
+                            <RatingAndChange ratings side=Color::Black/>
                         </Show>
                     </div>
                 </div>

--- a/apis/src/components/molecules/rating_and_change.rs
+++ b/apis/src/components/molecules/rating_and_change.rs
@@ -7,9 +7,10 @@ use std::cmp::Ordering;
 #[component]
 pub fn RatingAndChange(
     #[prop(optional)] extend_tw_classes: &'static str,
-    ratings: RatingChangeInfo,
+    ratings: StoredValue<RatingChangeInfo>,
     side: Color,
 ) -> impl IntoView {
+    let ratings = ratings();
     let (rating_change, rating) = match side {
         Color::White => (ratings.white_rating_change, ratings.white_rating),
 
@@ -42,10 +43,11 @@ pub fn RatingAndChangeDynamic(
         {move || {
             ratings()
                 .map(|ratings| {
+                    let ratings = StoredValue::new(ratings);
                     view! {
                         <RatingAndChange
                             extend_tw_classes=extend_tw_classes
-                            ratings=ratings
+                            ratings
                             side=side
                         />
                     }

--- a/apis/src/components/molecules/thumbnail_pieces.rs
+++ b/apis/src/components/molecules/thumbnail_pieces.rs
@@ -7,8 +7,8 @@ use hive_lib::Position;
 use leptos::*;
 
 #[component]
-pub fn ThumbnailPieces(game: GameResponse) -> impl IntoView {
-    let state = store_value(game.create_state());
+pub fn ThumbnailPieces(game: StoredValue<GameResponse>) -> impl IntoView {
+    let state = store_value(game().create_state());
     let thumbnail_pieces = move || {
         let mut pieces = Vec::new();
         for r in 0..32 {

--- a/apis/src/responses/user.rs
+++ b/apis/src/responses/user.rs
@@ -27,12 +27,11 @@ impl UserResponse {
     pub fn rating_for_speed(&self, game_speed: &GameSpeed) -> u64 {
         match game_speed {
             GameSpeed::Blitz => self.blitz(),
-            GameSpeed::Correspondence => self.correspondence(),
+            GameSpeed::Correspondence | GameSpeed::Untimed => self.correspondence(),
             GameSpeed::Bullet => self.bullet(),
             GameSpeed::Rapid => self.rapid(),
             GameSpeed::Classic => self.classic(),
             GameSpeed::Puzzle => self.puzzle(),
-            GameSpeed::Untimed => 0,
         }
     }
 


### PR DESCRIPTION
Fixes css issues with long usernames in the game_preview, used for displaying Tv games and tournament games. 
Also refactors game_previews avoiding a lot of clones on the whole game_response.

+ fixes an inconsistency with onfoinf casual untimed games displaying a rating of 0 on the player profile.