### PR TITLE
Fixes multiple tab profile display bug

### DIFF
--- a/apis/src/components/organisms/dropdowns/chat.rs
+++ b/apis/src/components/organisms/dropdowns/chat.rs
@@ -39,7 +39,7 @@ pub fn ChatDropdown(destination: SimpleDestination) -> impl IntoView {
 
             dropdown_style=chat_style
             content=view! { <Icon icon=icondata::BiChatRegular class="w-4 h-4"/> }
-            id = "chat"
+            id="chat"
         >
             <ChatWindow destination=destination()/>
         </Hamburger>

--- a/apis/src/components/organisms/dropdowns/mobile.rs
+++ b/apis/src/components/organisms/dropdowns/mobile.rs
@@ -17,7 +17,7 @@ pub fn MobileDropdown() -> impl IntoView {
             button_style="py-1 transform transition-transform duration-300 active:scale-95 whitespace-nowrap block lg:hidden m-1"
             dropdown_style=DROPDOWN_MENU_STYLE
             content=view! { <Icon icon=icondata::ChMenuHamburger class="w-6 h-6"/> }
-            id = "Mobile"
+            id="Mobile"
         >
 
             <div class=div_style>

--- a/apis/src/components/organisms/dropdowns/notification.rs
+++ b/apis/src/components/organisms/dropdowns/notification.rs
@@ -47,7 +47,7 @@ pub fn NotificationDropdown() -> impl IntoView {
             button_style="h-full p-2 transform transition-transform duration-300 active:scale-95 whitespace-nowrap block"
             dropdown_style="mr-1 items-center xs:mt-0 mt-1 flex flex-col items-stretch absolute bg-even-light dark:bg-gray-950 border border-gray-300 rounded-md p-2 right-0"
             content=view! { <Icon icon=icondata::IoNotifications class=icon_style/> }
-            id = "Notifications"
+            id="Notifications"
         >
             <Show
                 when=has_notifications

--- a/apis/src/components/organisms/dropdowns/user.rs
+++ b/apis/src/components/organisms/dropdowns/user.rs
@@ -15,7 +15,7 @@ pub fn UserDropdown(username: String) -> impl IntoView {
             button_style="bg-button-dawn dark:bg-button-twilight text-white rounded-md px-2 py-1 m-1 hover:bg-pillbug-teal transform transition-transform duration-300 active:scale-95 whitespace-nowrap"
             dropdown_style="mr-1 xs:mt-0 mt-1 flex flex-col items-stretch absolute bg-even-light dark:bg-gray-950 text-black border border-gray-300 rounded-md p-2 right-0 lg:right-10"
             content=username.clone()
-            id = "Username"
+            id="Username"
         >
             <a
                 class=COMMON_LINK_STYLE

--- a/apis/src/providers/navigation_controller.rs
+++ b/apis/src/providers/navigation_controller.rs
@@ -9,6 +9,7 @@ use shared_types::{GameId, TournamentId};
 pub struct NavigationControllerSignal {
     pub game_signal: RwSignal<GameNavigationControllerState>,
     pub tournament_signal: RwSignal<TournamentNavigationControllerState>,
+    pub profile_signal: RwSignal<ProfileNavigationControllerState>,
 }
 
 impl Default for NavigationControllerSignal {
@@ -20,8 +21,9 @@ impl Default for NavigationControllerSignal {
 impl NavigationControllerSignal {
     pub fn new() -> Self {
         Self {
-            game_signal: create_rw_signal(GameNavigationControllerState::new()),
-            tournament_signal: create_rw_signal(TournamentNavigationControllerState::new()),
+            game_signal: RwSignal::new(GameNavigationControllerState::new()),
+            tournament_signal: RwSignal::new(TournamentNavigationControllerState::new()),
+            profile_signal: RwSignal::new(ProfileNavigationControllerState::new()),
         }
     }
 
@@ -80,6 +82,23 @@ impl GameNavigationControllerState {
 }
 
 impl Default for GameNavigationControllerState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProfileNavigationControllerState {
+    pub username: Option<String>,
+}
+
+impl ProfileNavigationControllerState {
+    pub fn new() -> Self {
+        Self { username: None }
+    }
+}
+
+impl Default for ProfileNavigationControllerState {
     fn default() -> Self {
         Self::new()
     }

--- a/apis/src/providers/websocket/games_search/handle.rs
+++ b/apis/src/providers/websocket/games_search/handle.rs
@@ -1,24 +1,37 @@
-use crate::{providers::games_search::ProfileGamesContext, responses::GamesSearchResponse};
+use crate::{
+    providers::{
+        games_search::ProfileGamesContext, navigation_controller::NavigationControllerSignal,
+    },
+    responses::GamesSearchResponse,
+};
 use leptos::*;
 use shared_types::GamesContextToUpdate;
 
 pub fn handle_games_search(results: GamesSearchResponse) {
     let ctx = expect_context::<ProfileGamesContext>();
+    let navi = expect_context::<NavigationControllerSignal>();
     match results.ctx_to_update {
-        GamesContextToUpdate::Profile => {
-            ctx.games.update(|games| {
-                if results.first_batch {
-                    *games = results.results;
-                } else {
-                    games.extend(results.results);
-                }
-            });
-            ctx.batch_info.update(|batch| {
-                *batch = results.batch;
-            });
-            ctx.more_games.update(|more_finished| {
-                *more_finished = results.more_rows;
-            });
+        GamesContextToUpdate::Profile(username) => {
+            if navi
+                .profile_signal
+                .get()
+                .username
+                .is_some_and(|v| v == username)
+            {
+                ctx.games.update(|games| {
+                    if results.first_batch {
+                        *games = results.results;
+                    } else {
+                        games.extend(results.results);
+                    }
+                });
+                ctx.batch_info.update(|batch| {
+                    *batch = results.batch;
+                });
+                ctx.more_games.update(|more_finished| {
+                    *more_finished = results.more_rows;
+                });
+            }
         }
     }
 }

--- a/apis/src/providers/websocket/player_profile/handle.rs
+++ b/apis/src/providers/websocket/player_profile/handle.rs
@@ -1,8 +1,21 @@
-use leptos::{expect_context, SignalSet};
+use leptos::{expect_context, SignalGet, SignalSet};
 
-use crate::{providers::games_search::ProfileGamesContext, responses::UserResponse};
+use crate::{
+    providers::{
+        games_search::ProfileGamesContext, navigation_controller::NavigationControllerSignal,
+    },
+    responses::UserResponse,
+};
 
 pub fn handle_player_profile(profile: UserResponse) {
     let ctx = expect_context::<ProfileGamesContext>();
-    ctx.user.set(Some(profile));
+    let navi = expect_context::<NavigationControllerSignal>();
+    if navi
+        .profile_signal
+        .get()
+        .username
+        .is_some_and(|v| v == profile.username)
+    {
+        ctx.user.set(Some(profile));
+    };
 }

--- a/apis/src/websockets/api/games_search.rs
+++ b/apis/src/websockets/api/games_search.rs
@@ -39,7 +39,7 @@ impl GamesSearchHandler {
         let response = GamesSearchResponse {
             results: game_responses,
             batch,
-            ctx_to_update: self.options.ctx_to_update,
+            ctx_to_update: self.options.ctx_to_update.clone(),
             more_rows: options.batch_size.map_or(false, |b| b == games.len()),
             first_batch: options.current_batch.is_none(),
         };

--- a/shared_types/src/games_query_options.rs
+++ b/shared_types/src/games_query_options.rs
@@ -82,7 +82,7 @@ pub struct GamesQueryOptions {
     pub batch_size: Option<usize>,
     pub game_progress: GameProgress,
 }
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum GamesContextToUpdate {
-    Profile,
+    Profile(String),
 }

--- a/shared_types/src/lib.rs
+++ b/shared_types/src/lib.rs
@@ -25,7 +25,7 @@ pub use conclusion::Conclusion;
 pub use game_speed::GameSpeed;
 pub use game_start::GameStart;
 pub use games_query_options::{
-    BatchInfo, GamesContextToUpdate, GamesQueryOptions, GameProgress, ResultType,
+    BatchInfo, GameProgress, GamesContextToUpdate, GamesQueryOptions, ResultType,
 };
 pub use newtypes::{ApisId, ChallengeId, GameId, Password, TournamentId};
 pub use pretty_string::PrettyString;


### PR DESCRIPTION
Fixes the bug, where opening multiple tabs of different player profiles would lead to all of them displaying the games and stats of the last one opened.

However, the fix was done in a quick way and does not follow the same pattern as the other things that get updated by the navigation controller signal.

The reason for this is in the base layout even though you have access to the location url of the page [use_params](https://docs.rs/leptos_router/latest/leptos_router/fn.use_params.html) does not seem to work correctly so I ended up updating the navigation controller further down in the profile component.

We could use this same use_params for the game and tournament, this would get rid of the need for regexes in the base layout however it would need a separate effect further down in the relevant component. 

Is that the better way to go? 
Or should I move the player profile update to base_layout like the rest (this would need another regex for the profile url I think)?
Keep it as is and refactor later?