### PR TITLE
Enable undoing first bug in analysis mode

### DIFF
--- a/apis/src/components/organisms/analysis/atoms.rs
+++ b/apis/src/components/organisms/analysis/atoms.rs
@@ -12,11 +12,9 @@ use tree_ds::prelude::Node;
 pub fn UndoButton() -> impl IntoView {
     let analysis = expect_context::<AnalysisSignal>().0;
     let is_disabled = move || {
-        analysis.get().map_or(true, |analysis| {
-            analysis
-                .current_node
-                .map_or(true, |n| n.get_parent_id().is_none())
-        })
+        analysis
+            .get()
+            .map_or(true, |analysis| analysis.current_node.is_none())
     };
     let undo = move |_| {
         analysis.update(|a| {


### PR DESCRIPTION
It is currently impossible to undo the first bug placement on the analysis board. This is desirable for users to explore openings in somewhat of a sandbox like environment. This change enables that option.