### PR TITLE
avoid custom debounce on profile

### DIFF
--- a/db/src/models/game.rs
+++ b/db/src/models/game.rs
@@ -1124,24 +1124,31 @@ impl Game {
                         Some(ResultType::Win) => Some(match color {
                             Some(Color::White) => Box::new(white_won.clone().and(is_white)),
                             Some(Color::Black) => Box::new(black_won.clone().and(is_black)),
-                            None => Box::new((white_won.clone().and(is_white)).or(black_won.clone().and(is_black))),
+                            None => Box::new(
+                                (white_won.clone().and(is_white))
+                                    .or(black_won.clone().and(is_black)),
+                            ),
                         }),
                         Some(ResultType::Loss) => Some(match color {
                             Some(Color::White) => Box::new(black_won.clone().and(is_white)),
                             Some(Color::Black) => Box::new(white_won.clone().and(is_black)),
-                            None => Box::new((white_won.clone().and(is_black)).or(black_won.clone().and(is_white))),
+                            None => Box::new(
+                                (white_won.clone().and(is_black))
+                                    .or(black_won.clone().and(is_white)),
+                            ),
                         }),
                         Some(ResultType::Draw) => Some(match color {
                             Some(Color::White) => Box::new(is_white.and(is_draw.clone())),
                             Some(Color::Black) => Box::new(is_black.and(is_draw.clone())),
-                            None => Box::new((is_white.and(is_draw.clone())).or(is_black.and(is_draw.clone()))),
+                            None => Box::new(
+                                (is_white.and(is_draw.clone())).or(is_black.and(is_draw.clone())),
+                            ),
                         }),
                         None => match color {
                             Some(Color::White) => Some(Box::new(is_white)),
                             Some(Color::Black) => Some(Box::new(is_black)),
                             None => None,
-                            
-                        }
+                        },
                     };
 
                 let combined_filter: Box<dyn BoxableExpression<_, _, SqlType = _>> =


### PR DESCRIPTION
Debouncing the function call to the db for 600ms can cause some polution in the list if scrolling and changing options quickly (multiple distinct batches displayed at the same time in the list)

if the intention is to stop the user from issuing too many requests, Debouncing the imput signal should also solve this issue while avoiding polution and allows us to get rid of custom debounce code. 

The 600ms debounce time makes the controller feel a lot more slow, so a delay value of 250ms was chosen instead of 600ms. If you feel some other value is adequate it would be good to know