### PR TITLE
fix tournament standings display

### DIFF
--- a/apis/src/components/organisms/header.rs
+++ b/apis/src/components/organisms/header.rs
@@ -45,7 +45,7 @@ pub fn Header() -> impl IntoView {
                                 Buy Game
                             </a>
                             <a
-                                class="block p-2 h-full font-bold uppercase whitespace-nowrap transition-transform duration-300 transform text-orange-twilight hover:text-pillbug-teal active:scale-95"
+                                class="block p-2 h-full font-bold whitespace-nowrap transition-transform duration-300 transform text-orange-twilight hover:text-pillbug-teal active:scale-95"
                                 href="/donate"
                             >
                                 Donate

--- a/apis/src/pages/home.rs
+++ b/apis/src/pages/home.rs
@@ -3,6 +3,7 @@ use crate::components::organisms::{
     challenges::Challenges, online_users::OnlineUsers, quickplay::QuickPlay, tv::Tv,
 };
 use leptos::*;
+
 #[component]
 pub fn Home() -> impl IntoView {
     view! {

--- a/apis/src/pages/tournaments.rs
+++ b/apis/src/pages/tournaments.rs
@@ -29,16 +29,26 @@ pub fn Tournaments() -> impl IntoView {
                     value=search
                 />
                 <For
-                    each=move || { tournament.summary.get().tournaments }
+                    each=move || {
+                        let mut v: Vec<_> = tournament
+                            .summary
+                            .get()
+                            .tournaments
+                            .into_iter()
+                            .collect();
+                        v.sort_by(|a, b| b.1.updated_at.cmp(&a.1.updated_at));
+                        v
+                    }
+
                     key=move |(nanoid, tournament)| {
                         (nanoid.to_owned(), tournament.updated_at, search())
                     }
-                    let:tournament
-                    children=move |tournament| {
+
+                    children=move |(_id, tournament)| {
                         if search().is_empty()
-                            || tournament.1.name.to_lowercase().contains(&search().to_lowercase())
+                            || tournament.name.to_lowercase().contains(&search().to_lowercase())
                         {
-                            view! { <TournamentRow tournament=tournament.1/> }
+                            view! { <TournamentRow tournament=tournament.clone()/> }
                         } else {
                             "".into_view()
                         }


### PR DESCRIPTION
- Simplify the code for tournament standings, this also fixes a bug that displays standings incorrectly when ties are present. All unit tests are passing.

- Head2head depends on its position on the tie breaker ordering, calculate purely online now and avoid doing so from player standings

- Sort tournaments by latest updated