### PR TITLE
Exposes ro and de, removes very incomplete locales, fixes typo

### DIFF
--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -83,18 +83,15 @@ ssr = [
 default = "en"
 locales = [
   "ca", 
-  "cs", 
   "de",
   "en", 
   "es", 
   "fr",
   "hu",
   "it", 
-  "ja", 
-  "nl", 
-  "pt", 
-  "ru", 
-  "sv"
+  "pt",
+  "ro", 
+  "ru" 
 ]
 namespaces = [
   "header", 

--- a/apis/locales/ca/profile.json
+++ b/apis/locales/ca/profile.json
@@ -17,7 +17,7 @@
         "losses": "Derrotes: {{count}}"
     },
     "player_color": "Color del jugador:",
-    "gamo_result": "Resultat de la partida:",
+    "game_result": "Resultat de la partida:",
     "include_speeds": "Velocitats incloses:",
     "color_buttons": {
         "white": "Blanc",

--- a/apis/locales/en/profile.json
+++ b/apis/locales/en/profile.json
@@ -15,13 +15,13 @@
         "draw": "Draw",
         "all": "All"
     },
-    "stats_box":{
+    "stats_box": {
         "total": "Total: {{count}}",
         "wins": "Wins: {{count}}",
         "losses": "Losses: {{count}}",
         "draws": "Draws: {{count}}"
     },
     "player_color": "Player color:",
-    "gamo_result": "Game result:",
+    "game_result": "Game result:",
     "include_speeds": "Included speeds:"
 }

--- a/apis/locales/es/profile.json
+++ b/apis/locales/es/profile.json
@@ -22,6 +22,6 @@
         "draws": "Empates: {{count}}"
     },
     "player_color": "Color del jugador:",
-    "gamo_result": "Resultado de la partida:",
+    "game_result": "Resultado de la partida:",
     "include_speeds": "Velodidades incluidas:"
 }

--- a/apis/locales/fr/profile.json
+++ b/apis/locales/fr/profile.json
@@ -21,6 +21,6 @@
         "wins": "Victoires : {{count}}",
         "losses": "Défaites : {{count}}"
     },
-    "gamo_result": "Résultat de la partie :",
+    "game_result": "Résultat de la partie :",
     "player_color": "Couleur du joueur :"
 }

--- a/apis/locales/it/profile.json
+++ b/apis/locales/it/profile.json
@@ -22,6 +22,6 @@
         "draws": "Patte: {{count}}"
     },
     "player_color": "Colore giocatore:",
-    "gamo_result": "Risultato della partita:",
+    "game_result": "Risultato della partita:",
     "include_speeds": "Velocitá incluse:"
 }

--- a/apis/locales/pt/profile.json
+++ b/apis/locales/pt/profile.json
@@ -22,6 +22,6 @@
         "wins": "Vitórias: {{count}}"
     },
     "player_color": "Cor do jogador:",
-    "gamo_result": "Resultado do jogo:",
+    "game_result": "Resultado do jogo:",
     "include_speeds": "Velocidades incluídas:"
 }

--- a/apis/locales/ro/profile.json
+++ b/apis/locales/ro/profile.json
@@ -22,6 +22,6 @@
         "draws": "Remize: {{count}}"
     },
     "player_color": "Culoarea jucătorului:",
-    "gamo_result": "Rezultat:",
+    "game_result": "Rezultat:",
     "include_speeds": "Categorii timp:"
 }

--- a/apis/locales/ru/profile.json
+++ b/apis/locales/ru/profile.json
@@ -5,7 +5,7 @@
         "draws": "Ничьих: {{count}}",
         "losses": "Поражений: {{count}}"
     },
-    "gamo_result": "Результат партии:",
+    "game_result": "Результат партии:",
     "include_speeds": "Контроль времени:",
     "game_buttons": {
         "unstarted": "Неначатые турнирные игры",

--- a/apis/src/components/organisms/dropdowns/locale.rs
+++ b/apis/src/components/organisms/dropdowns/locale.rs
@@ -6,10 +6,10 @@ use leptos::*;
 const DROPDOWN_MENU_STYLE: &str = "flex flex-col items-stretch absolute bg-even-light dark:bg-gray-950 text-black border border-gray-300 rounded-md left-34 p-2";
 
 // Commented out very incomplete locales (< 30% translated)
-const ALL_LOCALES: [Locale; 8] = [
+const ALL_LOCALES: [Locale; 10] = [
     Locale::ca,
     //    Locale::cs,
-    //    Locale::de,
+    Locale::de,
     Locale::en,
     Locale::es,
     Locale::fr,
@@ -18,6 +18,7 @@ const ALL_LOCALES: [Locale; 8] = [
     //    Locale::ja,
     //    Locale::nl,
     Locale::pt,
+    Locale::ro,
     Locale::ru,
     //    Locale::sv,
 ];

--- a/apis/src/pages/profile_view.rs
+++ b/apis/src/pages/profile_view.rs
@@ -136,7 +136,7 @@ pub fn ProfileView(children: ChildrenFn) -> impl IntoView {
                             </RadioGroupItem>
                         </RadioGroupRoot>
                         <Show when=move || controls().tab_view == GameProgress::Finished>
-                            <span class="font-bold text-md">{t!(i18n, profile.gamo_result)}</span>
+                            <span class="font-bold text-md">{t!(i18n, profile.game_result)}</span>
                             <RadioGroupRoot
                                 attr:class="flex flex-wrap gap-1"
                                 value=signal_debounced(


### PR DESCRIPTION
By removing the really incomplete languages form the toml we get rid of hundreds of warnings.