### PR TITLE
fix pwa cookie

### DIFF
--- a/apis/src/providers/config.rs
+++ b/apis/src/providers/config.rs
@@ -31,7 +31,7 @@ impl Config {
         use_cookie_with_options::<ConfigOpts, Base64<MsgpackSerdeCodec>>(
             USER_CONFIG_COOKIE,
             UseCookieOptions::default()
-                .same_site(SameSite::Strict)
+                .same_site(SameSite::Lax)
                 .secure(true)
                 .expires(exp),
         )


### PR DESCRIPTION
Having the cookie's SameSite attribute as strict doesn't work for the mobile PWA and the cookie gets reset when closing the app

Setting the SameSite as Lax, properly persists the cookie