### PR TITLE
better authctx

### DIFF
--- a/apis/src/websocket/client_handlers/server_user_conf.rs
+++ b/apis/src/websocket/client_handlers/server_user_conf.rs
@@ -1,8 +1,18 @@
-use crate::providers::AuthContext;
-use leptos::prelude::expect_context;
+use crate::{functions::accounts::get::get_account, providers::{websocket::WebsocketContext, AuthContext}};
+use leptos::{prelude::{expect_context, Set}, task::spawn};
 pub fn handle_server_user_conf(success: bool) {
     let auth_context = expect_context::<AuthContext>();
     if success {
-        auth_context.user.refetch();
+        spawn(async move {
+            let account = get_account().await;
+            if let Ok(account) = account {
+                auth_context.user.set(Some(Ok(account)));
+                let websocket_context = expect_context::<WebsocketContext>();
+                websocket_context.close();
+                websocket_context.open();
+            } else {
+                auth_context.user.set(None);
+            }
+        });
     }
 }


### PR DESCRIPTION
Remove the resource from user auth, use a regular RwSignal and rely on watch to keep it updated, this avoids the following error

```
At ..., you are reading a resource in hydrate mode outside a <Suspense/> or <Transition/> or effect. This can cause hydration mismatch errors and loses out on a significant performance optimization. To fix this issue, you can either: 
Wrap the place where you read the resource in a <Suspense/> or <Transition/> component, or
Switch to using LocalResource::new(), which will wait to load the resource until the app is hydrated on the client side. (This will have worse performance in most cases.)
```

it is still required to remove the websocket context from these effects, so this does not fix the issue entirely 