### PR TITLE
configs work!!!

### DIFF
--- a/apis/src/app.rs
+++ b/apis/src/app.rs
@@ -76,7 +76,9 @@ pub fn App() -> impl IntoView {
     view! {
         <I18nContextProvider cookie_options=CookieOptions::default()
             .max_age(LOCALE_MAX_AGE)
-            .same_site(SameSite::Lax)>
+            .same_site(SameSite::Lax)
+            .path("/")
+            >
             <Stylesheet id="leptos" href="/pkg/HiveGame.css" />
             <Router>
                 <Routes

--- a/apis/src/components/atoms/active.rs
+++ b/apis/src/components/atoms/active.rs
@@ -12,7 +12,7 @@ pub fn Active(
     #[prop(optional)] extend_tw_classes: &'static str,
 ) -> impl IntoView {
     let config = expect_context::<Config>().0;
-    let straight = move || config().tile_design == TileDesign::ThreeD;
+    let straight = move || config().unwrap_or_default().tile_design == TileDesign::ThreeD;
     let center = move || SvgPos::center_for_level(position, level(), straight());
     let transform = move || format!("translate({},{})", center().0, center().1);
     let mut game_state_signal = expect_context::<GameStateSignal>();

--- a/apis/src/components/atoms/create_challenge_button.rs
+++ b/apis/src/components/atoms/create_challenge_button.rs
@@ -15,14 +15,14 @@ pub fn CreateChallengeButton(
             "w-full h-full stroke-1 stroke-black",
         ),
         ColorChoice::White => {
-            if config().prefers_dark {
+            if config().unwrap_or_default().prefers_dark {
                 (icondata::BsHexagonFill, "w-full h-full fill-white")
             } else {
                 (icondata::BsHexagon, "w-full h-full stroke-1 stroke-black")
             }
         }
         ColorChoice::Black => {
-            if config().prefers_dark {
+            if config().unwrap_or_default().prefers_dark {
                 (icondata::BsHexagon, "w-full h-full stroke-1 stroke-white")
             } else {
                 (icondata::BsHexagonFill, "w-full h-full fill-black")

--- a/apis/src/components/atoms/last_move.rs
+++ b/apis/src/components/atoms/last_move.rs
@@ -12,7 +12,7 @@ pub fn LastMove(
     direction: Direction,
 ) -> impl IntoView {
     let config = expect_context::<Config>().0;
-    let straight = move || config().tile_design == TileDesign::ThreeD;
+    let straight = move || config().unwrap_or_default().tile_design == TileDesign::ThreeD;
     let center = move || SvgPos::center_for_level(position, level(), straight());
     let transform = move || format!("translate({},{})", center().0, center().1);
     let href = move || match direction {

--- a/apis/src/components/atoms/logo.rs
+++ b/apis/src/components/atoms/logo.rs
@@ -6,7 +6,7 @@ pub fn Logo(tw_class: &'static str) -> impl IntoView {
     let config = expect_context::<Config>().0;
     let orientation_signal = expect_context::<OrientationSignal>();
     let logo = move || {
-        let theme = if config().prefers_dark { "_dark" } else { "" };
+        let theme = if config().unwrap_or_default().prefers_dark { "_dark" } else { "" };
         let orientation = if orientation_signal.orientation_vertical.get() {
             "inline"
         } else {

--- a/apis/src/components/atoms/piece.rs
+++ b/apis/src/components/atoms/piece.rs
@@ -18,13 +18,13 @@ pub fn PieceWithoutOnClick(
     let piece = piece.get_untracked();
     let config = expect_context::<Config>().0;
     let position = position.get_untracked();
-    let three_d = move || config().tile_design == TileDesign::ThreeD;
+    let three_d = move || config().unwrap_or_default().tile_design == TileDesign::ThreeD;
     let center = move || SvgPos::center_for_level(position, level(), three_d());
     let order = piece.order();
     let ds_transform = move || format!("translate({},{})", center().0, center().1);
     let position_transform = move || format!("translate({},{})", center().0, center().1,);
     let rotate_transform = move || {
-        if config().tile_rotation == TileRotation::No {
+        if config().unwrap_or_default().tile_rotation == TileRotation::No {
             String::new()
         } else {
             format!("rotate({})", order.saturating_sub(1) * 60)
@@ -34,7 +34,7 @@ pub fn PieceWithoutOnClick(
     let bug = piece.bug();
     let color = piece.color();
 
-    let dot_color = move || match config().tile_design {
+    let dot_color = move || match config().unwrap_or_default().tile_design {
         TileDesign::Official | TileDesign::ThreeD => match bug {
             Bug::Ant => "color: #289ee0",
             Bug::Beetle => "color: #9a7fc7",
@@ -61,7 +61,7 @@ pub fn PieceWithoutOnClick(
 
     let active_piece = create_read_slice(game_state.signal, |gs| gs.move_info.active);
     let show_ds = move || {
-        let shadow = match config().tile_design {
+        let shadow = match config().unwrap_or_default().tile_design {
             TileDesign::Official => "/assets/tiles/common/all.svg#drop_shadow",
             TileDesign::Flat => "/assets/tiles/common/all.svg#drop_shadow",
             TileDesign::ThreeD => "/assets/tiles/3d/shadow.svg#dshadow",
@@ -84,19 +84,19 @@ pub fn PieceWithoutOnClick(
         }
     };
 
-    let dots = move || match config().tile_dots {
+    let dots = move || match config().unwrap_or_default().tile_dots {
         TileDots::No => String::new(),
         TileDots::Angled => format!("/assets/tiles/common/all.svg#a{order}"),
         TileDots::Vertical => format!("/assets/tiles/common/all.svg#v{order}"),
     };
 
-    let bug_svg = move || match config().tile_design {
+    let bug_svg = move || match config().unwrap_or_default().tile_design {
         TileDesign::Official => format!("/assets/tiles/official/official.svg#{}", bug.name()),
         TileDesign::Flat => format!("/assets/tiles/flat/flat.svg#{}", bug.name()),
         TileDesign::ThreeD => format!("/assets/tiles/3d/3d.svg#{}{}", color.name(), bug.name()),
     };
 
-    let tile_svg = move || match config().tile_design {
+    let tile_svg = move || match config().unwrap_or_default().tile_design {
         TileDesign::Official => format!("/assets/tiles/official/official.svg#{}", color.name()),
         TileDesign::Flat => format!("/assets/tiles/flat/flat.svg#{}", color.name()),
         TileDesign::ThreeD => format!("/assets/tiles/3d/3d.svg#{}", color.name()),

--- a/apis/src/components/atoms/status_indicator.rs
+++ b/apis/src/components/atoms/status_indicator.rs
@@ -46,7 +46,7 @@ pub fn StatusIndicator(username: Signal<String>) -> impl IntoView {
     view! {
         <Icon
             icon=icondata::BiCircleSolid
-            prop:class=move || format!("mr-1 pb-[2px] {}", icon_style())
+            attr:class=move || format!("mr-1 pb-[2px] {}", icon_style())
         />
     }
 }

--- a/apis/src/components/atoms/target.rs
+++ b/apis/src/components/atoms/target.rs
@@ -15,7 +15,7 @@ pub fn Target(
     #[prop(optional)] extend_tw_classes: &'static str,
 ) -> impl IntoView {
     let config = expect_context::<Config>().0;
-    let straight = move || config().tile_design == TileDesign::ThreeD;
+    let straight = move || config().unwrap_or_default().tile_design == TileDesign::ThreeD;
     let center = move || SvgPos::center_for_level(position, level(), straight());
     let transform = move || format!("translate({},{})", center().0, center().1);
     let mut game_state = expect_context::<GameStateSignal>();

--- a/apis/src/components/layouts/base_layout.rs
+++ b/apis/src/components/layouts/base_layout.rs
@@ -65,6 +65,7 @@ pub fn BaseLayout(children: ChildrenFn) -> impl IntoView {
     let is_tall = use_media_query("(min-height: 100vw)");
     let chat_dropdown_open = RwSignal::new(false);
     let orientation_vertical = Signal::derive(move || is_tall() || chat_dropdown_open());
+    let mut navi = expect_context::<NavigationControllerSignal>();
     provide_context(OrientationSignal {
         is_tall,
         chat_dropdown_open,
@@ -93,7 +94,7 @@ pub fn BaseLayout(children: ChildrenFn) -> impl IntoView {
     }
 
     let color_scheme_meta = move || {
-        if config().prefers_dark {
+        if config().unwrap_or_default().prefers_dark {
             "dark".to_string()
         } else {
             "light".to_string()
@@ -129,7 +130,6 @@ pub fn BaseLayout(children: ChildrenFn) -> impl IntoView {
 
     Effect::new(move |_| {
         let location = use_location();
-        let mut navi = expect_context::<NavigationControllerSignal>();
         let pathname = (location.pathname)();
 
         let game_id = if let Some(caps) = GAME_NANOID.captures(&pathname) {
@@ -212,7 +212,7 @@ pub fn BaseLayout(children: ChildrenFn) -> impl IntoView {
         <Meta name="apple-mobile-web-app-status-bar-style" content="black" />
         <Script src="/assets/js/pwa.js" />
         <Html attr:class=move || {
-            match config().prefers_dark {
+            match config().unwrap_or_default().prefers_dark {
                 true => "dark",
                 false => "",
             }

--- a/apis/src/components/molecules/challenge_row.rs
+++ b/apis/src/components/molecules/challenge_row.rs
@@ -25,7 +25,7 @@ pub fn ChallengeRow(challenge: ChallengeResponse, single: bool) -> impl IntoView
             view! { <Icon icon=icondata::BsHexagonHalf attr:class="pb-[2px]" /> }.into_any()
         }
         ColorChoice::White => {
-            if config().prefers_dark {
+            if config().unwrap_or_default().prefers_dark {
                 view! { <Icon icon=icondata::BsHexagonFill attr:class="fill-white pb-[2px]" /> }
                     .into_any()
             } else {
@@ -34,7 +34,7 @@ pub fn ChallengeRow(challenge: ChallengeResponse, single: bool) -> impl IntoView
             }
         }
         ColorChoice::Black => {
-            if config().prefers_dark {
+            if config().unwrap_or_default().prefers_dark {
                 view! { <Icon icon=icondata::BsHexagon attr:class="stroke-white pb-[2px]" /> }
                     .into_any()
             } else {

--- a/apis/src/components/molecules/thumbnail_pieces.rs
+++ b/apis/src/components/molecules/thumbnail_pieces.rs
@@ -24,7 +24,7 @@ pub fn ThumbnailPieces(game: StoredValue<GameResponse>) -> impl IntoView {
     };
 
     let config = expect_context::<Config>().0;
-    let straight = move || config().tile_design == TileDesign::ThreeD;
+    let straight = move || config().unwrap_or_default().tile_design == TileDesign::ThreeD;
 
     let (width, height) = (400.0_f32, 510.0_f32);
     // TODO: because Thumbnail pieces is used in two places, this leads to weirdness in the TV

--- a/apis/src/components/organisms/board.rs
+++ b/apis/src/components/organisms/board.rs
@@ -62,6 +62,7 @@ pub fn Board(
 ) -> impl IntoView {
     let mut game_state = expect_context::<GameStateSignal>();
     let target_stack = expect_context::<TargetStack>().0;
+    let config = expect_context::<Config>().0;
     let is_panning = RwSignal::new(false);
     let has_zoomed = RwSignal::new(false);
     let viewbox_signal = RwSignal::new(ViewBoxControls::new());
@@ -116,8 +117,7 @@ pub fn Board(
     };
 
     let straight = {
-        let config = expect_context::<Config>().0;
-        config().tile_design == TileDesign::ThreeD
+        config().unwrap_or_default().tile_design == TileDesign::ThreeD
     };
 
     let update_once = Effect::new(move |_| {
@@ -143,7 +143,7 @@ pub fn Board(
 
     let straight = {
         let config = expect_context::<Config>().0;
-        config().tile_design == TileDesign::ThreeD
+        config().unwrap_or_default().tile_design == TileDesign::ThreeD
     };
 
     //This handles board resizes

--- a/apis/src/components/organisms/confirm_mode_toggle.rs
+++ b/apis/src/components/organisms/confirm_mode_toggle.rs
@@ -22,8 +22,7 @@ pub fn ConfirmModeToggle(game_speed: GameSpeed) -> impl IntoView {
 pub fn ConfirmModeButton(move_confirm: MoveConfirm, game_speed: GameSpeed) -> impl IntoView {
     let move_confirm = Signal::derive(move || move_confirm.clone());
     let game_speed = Signal::derive(move || game_speed.clone());
-    let config = expect_context::<Config>().0;
-    let (_, set_cookie) = Config::get_cookie();
+    let Config(config, set_cookie) = expect_context();
     let (title, icon) = match move_confirm() {
         MoveConfirm::Clock => ("Click on your clock", icondata::BiStopwatchRegular),
         MoveConfirm::Double => ("Double click", icondata::TbHandTwoFingers),
@@ -31,7 +30,7 @@ pub fn ConfirmModeButton(move_confirm: MoveConfirm, game_speed: GameSpeed) -> im
     };
     let is_active = move || {
         let inactive_class = "bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal";
-        config()
+        config().unwrap_or_default()
             .confirm_mode
             .get(&game_speed())
             .map_or(inactive_class, |preferred| {

--- a/apis/src/components/organisms/darkmode_toggle.rs
+++ b/apis/src/components/organisms/darkmode_toggle.rs
@@ -3,8 +3,7 @@ use leptos::prelude::*;
 
 #[component]
 pub fn DarkModeToggle(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
-    let config = expect_context::<Config>().0;
-    let (_, set_cookie) = Config::get_cookie();
+    let Config(config, set_cookie) = expect_context();
     view! {
         <div class=format!(
             "inline-flex justify-center items-center m-1 rounded dark:bg-orange-twilight bg-gray-950 {extend_tw_classes}",
@@ -15,15 +14,15 @@ pub fn DarkModeToggle(#[prop(optional)] extend_tw_classes: &'static str) -> impl
                     set_cookie
                         .update(|c| {
                             if let Some(cookie) = c {
-                                cookie.prefers_dark = !config().prefers_dark;
+                                cookie.prefers_dark = !cookie.prefers_dark;
                             }
                         });
                 }
 
                 class="flex justify-center items-center px-1 py-2 w-full h-full"
-                value=move || { if config().prefers_dark { "dark" } else { "light" } }
+                value=move || { if config().unwrap_or_default().prefers_dark { "dark" } else { "light" } }
                 inner_html=move || {
-                    if config().prefers_dark {
+                    if config().unwrap_or_default().prefers_dark {
                         r#"<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-4 text-hive-black bg-orange-twilight dark:text-text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
                                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
                             </svg>

--- a/apis/src/components/organisms/sound_toggle.rs
+++ b/apis/src/components/organisms/sound_toggle.rs
@@ -4,10 +4,9 @@ use leptos_icons::Icon;
 
 #[component]
 pub fn SoundToggle() -> impl IntoView {
-    let config = expect_context::<Config>().0;
-    let (_, set_cookie) = Config::get_cookie();
+    let Config(config, set_cookie) = expect_context();
     let icon = move || {
-        let icon = if config().prefers_sound {
+        let icon = if config().unwrap_or_default().prefers_sound {
             icondata::BiVolumeFullRegular
         } else {
             icondata::BiVolumeMuteRegular
@@ -22,7 +21,7 @@ pub fn SoundToggle() -> impl IntoView {
                     set_cookie
                         .update(|c| {
                             if let Some(cookie) = c {
-                                cookie.prefers_sound = !config().prefers_sound;
+                                cookie.prefers_sound = !cookie.prefers_sound;
                             }
                         });
                 }

--- a/apis/src/components/organisms/tile_design_toggle.rs
+++ b/apis/src/components/organisms/tile_design_toggle.rs
@@ -37,10 +37,9 @@ pub fn TileDesignToggle() -> impl IntoView {
 pub fn TileDesignButton(tile_design: TileDesign) -> impl IntoView {
     let i18n = use_i18n();
     let tile_design = Signal::derive(move || tile_design.clone());
-    let config = expect_context::<Config>().0;
-    let (_, set_cookie) = Config::get_cookie();
+    let Config(config, set_cookie) = expect_context();
     let is_active = move || {
-        if config().tile_design == tile_design() {
+        if config().unwrap_or_default().tile_design == tile_design() {
             "bg-pillbug-teal"
         } else {
             "bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal"

--- a/apis/src/components/organisms/tile_dots_toggle.rs
+++ b/apis/src/components/organisms/tile_dots_toggle.rs
@@ -18,10 +18,9 @@ pub fn TileDotsToggle() -> impl IntoView {
 pub fn TileDotsButton(tile_dots: TileDots) -> impl IntoView {
     let i18n = use_i18n();
     let tile_dots = Signal::derive(move || tile_dots.clone());
-    let config = expect_context::<Config>().0;
-    let (_, set_cookie) = Config::get_cookie();
+    let Config(config, set_cookie) = expect_context();
     let is_active = move || {
-        if config().tile_dots == tile_dots() {
+        if config().unwrap_or_default().tile_dots == tile_dots() {
             "bg-pillbug-teal"
         } else {
             "bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal"

--- a/apis/src/components/organisms/tile_rotation_toggle.rs
+++ b/apis/src/components/organisms/tile_rotation_toggle.rs
@@ -18,10 +18,9 @@ pub fn TileRotationToggle() -> impl IntoView {
 pub fn TileRotationButton(tile_rotation: TileRotation) -> impl IntoView {
     let i18n = use_i18n();
     let tile_rotation = StoredValue::new(tile_rotation);
-    let config = expect_context::<Config>().0;
-    let (_, set_cookie) = Config::get_cookie();
+    let Config(config, set_cookie) = expect_context();
     let is_active = move || {
-        if config().tile_rotation == tile_rotation.get_value() {
+        if config().unwrap_or_default().tile_rotation == tile_rotation.get_value() {
             "bg-pillbug-teal"
         } else {
             "bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal"

--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -21,7 +21,7 @@ if #[cfg(feature = "hydrate")] {
 
       console_error_panic_hook::set_once();
 
-      leptos::mount::mount_to_body(App);
+      leptos::mount::hydrate_body(App);
     }
 }
 }

--- a/apis/src/pages/play.rs
+++ b/apis/src/pages/play.rs
@@ -39,7 +39,7 @@ pub fn Play(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView 
             .loaded
             .get()
             .then(|| {
-                let preferred_confirms = config().confirm_mode;
+                let preferred_confirms = config().unwrap_or_default().confirm_mode;
                 game_state
                     .signal
                     .get_untracked()

--- a/apis/src/providers/config.rs
+++ b/apis/src/providers/config.rs
@@ -10,7 +10,11 @@ use std::str::FromStr;
 
 const USER_CONFIG_COOKIE: &str = "user_config";
 
-#[derive(Serialize, Deserialize, Clone)]
+// 1 year in milliseconds
+const CONF_MAX_AGE: i64 = 1000 * 60 * 60 * 24 * 365;
+
+
+#[derive(Serialize, Deserialize, Clone, Default)]
 pub struct ConfigOpts {
     pub confirm_mode: HashMap<GameSpeed, MoveConfirm>,
     pub tile_design: TileDesign,
@@ -19,74 +23,19 @@ pub struct ConfigOpts {
     pub prefers_sound: bool,
     pub prefers_dark: bool,
 }
-#[derive(Clone, Serialize, Debug)]
-pub struct Config(pub Signal<ConfigOpts>);
+#[derive(Clone, Debug)]
+pub struct Config(pub Signal<Option<ConfigOpts>>, pub WriteSignal<Option<ConfigOpts>>);
 
-impl Config {
-    pub fn get_cookie() -> (Signal<Option<ConfigOpts>>, WriteSignal<Option<ConfigOpts>>) {
-        let exp = Utc::now()
-            .checked_add_signed(chrono::Duration::days(365))
-            .unwrap()
-            .timestamp();
-        use_cookie_with_options::<ConfigOpts, Base64<MsgpackSerdeCodec>>(
+impl Default for Config {
+    fn default() -> Self {
+        let (cookie, set_cookie) = use_cookie_with_options::<ConfigOpts, Base64<MsgpackSerdeCodec>>(
             USER_CONFIG_COOKIE,
             UseCookieOptions::default()
                 .same_site(SameSite::Lax)
                 .secure(true)
-                .expires(exp),
-        )
-    }
-}
-
-impl ConfigOpts {
-    //Could be removed eventually, only here to migrate old cookies
-    fn new_from_legacy() -> Self {
-        let (tile_dots, _) = use_cookie::<TileDots, Base64<MsgpackSerdeCodec>>("tile_dots");
-        let tile_dots = tile_dots().unwrap_or_default();
-
-        let (tile_design, _) = use_cookie::<TileDesign, FromToStringCodec>("tile_design");
-        let tile_design = tile_design().unwrap_or_default();
-
-        let (tile_rotation, _) =
-            use_cookie::<TileRotation, Base64<MsgpackSerdeCodec>>("tile_rotation");
-        let tile_rotation = tile_rotation().unwrap_or_default();
-
-        let (prefers_sound, _) = use_cookie::<bool, Base64<MsgpackSerdeCodec>>("sound");
-        let prefers_sound = prefers_sound().unwrap_or_default();
-
-        let (prefers_dark, _) = use_cookie::<String, FromToStringCodec>("darkmode");
-        let prefers_dark = prefers_dark().is_some_and(|v| v == "true");
-
-        let mut confirm_mode = HashMap::new();
-        for speed in GameSpeed::all().iter() {
-            let move_confirm = &format!("{}_confirm_mode", speed);
-            let (move_confirm, _) = use_cookie::<String, FromToStringCodec>(move_confirm);
-            let move_confirm = move_confirm().and_then(|c| MoveConfirm::from_str(&c).ok());
-            confirm_mode.insert(speed.clone(), move_confirm.unwrap_or_default());
-        }
-        Self {
-            confirm_mode,
-            tile_dots,
-            tile_design,
-            tile_rotation,
-            prefers_sound,
-            prefers_dark,
-        }
-    }
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        let (cookie, set_cookie) = Config::get_cookie();
-        Self(Signal::derive(move || {
-            if let Some(cookie) = cookie() {
-                cookie
-            } else {
-                let opts = ConfigOpts::new_from_legacy();
-                set_cookie(Some(opts.clone()));
-                opts
-            }
-        }))
+                .max_age(CONF_MAX_AGE)
+                .path("/"));
+        Self(cookie, set_cookie)
     }
 }
 

--- a/apis/src/providers/sounds.rs
+++ b/apis/src/providers/sounds.rs
@@ -27,7 +27,7 @@ pub struct Sounds {
 impl Sounds {
     pub fn play_sound(&self, kind: SoundType) {
         let config = expect_context::<Config>().0;
-        if !config().prefers_sound {
+        if !config().unwrap_or_default().prefers_sound {
             return;
         };
         if let Some(Ok(s)) = self.client_data.get().as_deref() {

--- a/apis/src/providers/websocket.rs
+++ b/apis/src/providers/websocket.rs
@@ -78,8 +78,7 @@ fn fix_wss(url: &str) -> String {
 
 pub fn provide_websocket(url: &str) {
     let url = fix_wss(url);
-    let owner = Owner::current().unwrap();
-    //log!("Establishing new websocket connection");
+   // log!("Establishing new websocket connection");
     let UseWebSocketReturn {
         message,
         send,
@@ -90,7 +89,7 @@ pub fn provide_websocket(url: &str) {
     } = use_websocket_with_options::<WebsocketMessage, WebsocketMessage, MsgpackSerdeCodec, _, _>(
         &url,
         UseWebSocketOptions::default()
-            .on_message(move |m| owner.with(|| on_message_callback(m)))
+            .on_message(on_message_callback)
             .immediate(false),
     );
     provide_context(WebsocketContext::new(


### PR DESCRIPTION
#### Config cookie rework
- Provide signals through context so we only invoke use_cookie once
- Remove the retrieve from legacy method, to make the code cleaner
- Dont use derived signals on the cookie

#### use attr instead of prop so status indicator works

#### remove forcing owner of the websocket, now it should always be clear through context passing