### PR TITLE
Add openssl to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
             flyctl
             cargo-leptos
             tailwindcss
+            openssl
             (rust-bin.selectLatestNightlyWith( toolchain: toolchain.default.override {
               extensions= [ "rust-src" "rust-analyzer" ];
               targets = [ "wasm32-unknown-unknown" ];


### PR DESCRIPTION
openssl is now a system dependency.

Without it, the building process returns the following error:

```
target/debug/apis: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or director
```