### PR TITLE
Changes auto accept challenge logic

### DIFF
--- a/apis/src/responses/challenge.rs
+++ b/apis/src/responses/challenge.rs
@@ -93,15 +93,8 @@ fn is_compatible(
             ColorChoice::Black => challenge.color_choice == ColorChoice::White,
         }
         && challenge.challenger.username != challenger_name
-        && match (details.band_lower, details.band_upper) {
-            (None, None) => true,
-            (Some(lower), None) => lower as u64 <= challenge.challenger_rating,
-            (None, Some(upper)) => upper as u64 >= challenge.challenger_rating,
-            (Some(lower), Some(upper)) => {
-                lower as u64 <= challenge.challenger_rating
-                    && upper as u64 >= challenge.challenger_rating
-            }
-        }
+        && (details.band_lower, details.band_upper) == (None, None)
+        && (challenge.band_lower, challenge.band_upper) == (None, None)
 }
 
 fn has_same_details(

--- a/apis/src/websocket/server_handlers/challenges/accept.rs
+++ b/apis/src/websocket/server_handlers/challenges/accept.rs
@@ -61,7 +61,7 @@ impl AcceptHandler {
                 messages.push(InternalServerMessage {
                     destination: MessageDestination::User(self.user_id),
                     message: ServerMessage::Error(format!(
-                        "{rating} is above the rating band of {band_lower}"
+                        "{rating} is below the rating band of {band_lower}"
                     )),
                 });
                 return Ok(messages);


### PR DESCRIPTION
Properly fixing the reported bug of getting into a game with someone outside your current challenge rating restrictions is a lot more complicated.

This change prevents that from happening by only auto-pairing unrestricted challenges.