### PR TITLE
Changes how analysis loads games

### DIFF
--- a/apis/src/app.rs
+++ b/apis/src/app.rs
@@ -141,6 +141,7 @@ pub fn App() -> impl IntoView {
                             view=|| view! { <ChallengeView /> }
                         />
                         <Route path=path!("/analysis") view=|| view! { <Analysis /> } />
+                        <Route path=path!("/analysis/:nanoid") view=|| view! { <Analysis /> } />
                         <ProtectedRoute
                             condition=is_logged_in
                             path=path!("/config")

--- a/apis/src/components/molecules/analysis_and_download.rs
+++ b/apis/src/components/molecules/analysis_and_download.rs
@@ -2,11 +2,14 @@ use crate::components::atoms::download_pgn::DownloadPgn;
 use crate::providers::game_state::GameStateSignal;
 use leptos::prelude::*;
 use leptos_icons::*;
+use leptos_router::hooks::{use_params_map, use_query_map};
 use shared_types::GameSpeed;
 
 #[component]
 pub fn AnalysisAndDownload() -> impl IntoView {
     let game_state = expect_context::<GameStateSignal>();
+    let params = use_params_map();
+    let queries = use_query_map();
     let correspondence = create_read_slice(game_state.signal, |gs| {
         gs.game_response.as_ref().is_some_and(|gr| {
             gr.speed == GameSpeed::Correspondence || gr.speed == GameSpeed::Untimed
@@ -14,11 +17,25 @@ pub fn AnalysisAndDownload() -> impl IntoView {
     });
     let is_finished = game_state.is_finished();
 
+    let analysis_url = move || {
+        if let Some(nanoid) = params.get().get("nanoid") {
+            let mut url = format!("/analysis/{nanoid}");
+
+            if let Some(move_param) = queries.get().get("move") {
+                url = format!("{url}?move={move_param}");
+            }
+
+            url
+        } else {
+            "/analysis".to_string()
+        }
+    };
+
     view! {
         <Show when=move || is_finished() || correspondence()>
             <div class="flex justify-center items-center place-self-start">
                 <a
-                    href="/analysis"
+                    href=analysis_url
                     class="justify-self-end place-self-center m-1 text-white rounded duration-300 no-link-style bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal"
                 >
                     <Icon icon=icondata::TbMicroscope attr:class="py-1 w-7 h-7" />

--- a/apis/src/components/organisms/analysis/save_and_load.rs
+++ b/apis/src/components/organisms/analysis/save_and_load.rs
@@ -61,11 +61,9 @@ pub fn LoadTree() -> impl IntoView {
             .as_string()
             .and_then(|string| History::from_pgn_str(string).ok())
             .and_then(|history| hive_lib::State::new_from_history(&history).ok())
-            .and_then(|state| {
-                game_state.signal.update(|gs| gs.state = state);
-                AnalysisTree::from_state(game_state)
-            })
-            .map(|tree| {
+            .map(|state| {
+                game_state.signal.update(|gs| gs.state = state.clone());
+                let tree = AnalysisTree::from_loaded_state(game_state, &state);
                 analysis.set(LocalStorage::wrap(tree));
             })
     };

--- a/apis/src/components/organisms/history.rs
+++ b/apis/src/components/organisms/history.rs
@@ -6,6 +6,7 @@ use crate::providers::timer::TimerSignal;
 use hive_lib::GameStatus;
 use leptos::{html, prelude::*};
 use leptos_icons::*;
+use leptos_router::hooks::{use_params_map, use_query_map};
 use shared_types::{PrettyString, TimeMode};
 
 static NANOS_IN_SECOND: u64 = 1000000000_u64;
@@ -87,6 +88,8 @@ pub fn HistoryMove(
 #[component]
 pub fn History(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
     let game_state = expect_context::<game_state::GameStateSignal>();
+    let params = use_params_map();
+    let queries = use_query_map();
     let state = create_read_slice(game_state.signal, |gs| gs.state.clone());
     let repetitions = create_read_slice(game_state.signal, |gs| {
         gs.game_response.as_ref().map(|gr| gr.repetitions.clone())
@@ -122,6 +125,20 @@ pub fn History(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoVi
             false
         }
     };
+
+    let analysis_url = move || {
+        if let Some(nanoid) = params.get().get("nanoid") {
+            let mut url = format!("/analysis/{nanoid}");
+
+            if let Some(move_param) = queries.get().get("move") {
+                url = format!("{url}?move={move_param}");
+            }
+
+            url
+        } else {
+            "/analysis".to_string()
+        }
+    };
     view! {
         <div class=format!("h-full flex flex-col pb-4 {extend_tw_classes}")>
 
@@ -142,7 +159,7 @@ pub fn History(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoVi
                     <div class="col-span-4 text-center">{game_result}</div>
                     <div class="col-span-4 text-center">{conclusion}</div>
                     <a
-                        href="/analysis"
+                        href=analysis_url
                         class="col-span-4 place-self-center w-4/5 text-white rounded duration-300 no-link-style bg-button-dawn dark:bg-button-twilight hover:bg-pillbug-teal"
                     >
                         <div class="flex gap-1 justify-center items-center">

--- a/apis/src/pages/analysis.rs
+++ b/apis/src/pages/analysis.rs
@@ -8,14 +8,19 @@ use crate::{
             reserve::{Alignment, Reserve},
         },
     },
+    functions::games::get::get_game_from_nanoid,
     pages::play::CurrentConfirm,
     providers::{
         analysis::{AnalysisSignal, AnalysisTree, TreeNode},
         game_state::GameStateSignal,
+        AuthContext,
     },
+    responses::GameResponse,
 };
-use hive_lib::Color;
+use hive_lib::{Color, GameStatus, GameType};
 use leptos::prelude::*;
+use leptos_router::hooks::{use_params_map, use_query_map};
+use shared_types::{GameId, TimeMode};
 use std::collections::HashSet;
 
 #[derive(Clone)]
@@ -24,58 +29,107 @@ pub struct ToggleStates(pub RwSignal<HashSet<i32>>);
 #[component]
 pub fn Analysis(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
     let game_state = expect_context::<GameStateSignal>();
-    provide_context(AnalysisSignal(RwSignal::new(LocalStorage::wrap(
-        AnalysisTree::from_state(game_state).unwrap_or_default(),
-    ))));
+    let auth_context = expect_context::<AuthContext>();
+    let params = use_params_map();
+    let queries = use_query_map();
+    let game_id = Memo::new(move |_| params().get("nanoid").map(|s| GameId(s.to_owned())));
+    let move_number = StoredValue::new(
+        queries
+            .get_untracked()
+            .get("move")
+            .and_then(|s| s.parse::<usize>().ok())
+            .map(|n| n.saturating_sub(1)),
+    );
+
     provide_context(ToggleStates(RwSignal::new(HashSet::new())));
     provide_context(CurrentConfirm(Memo::new(move |_| MoveConfirm::Single)));
     let vertical = expect_context::<OrientationSignal>().orientation_vertical;
-    let parent_container_style = move || {
-        if vertical() {
-            "flex flex-col h-full"
-        } else {
-            "max-h-[100dvh] min-h-[100dvh] grid grid-cols-10  grid-rows-6 pr-1"
-        }
+
+    let should_block_analysis = move |game_response: &GameResponse| -> bool {
+        let Some(user) = auth_context.user.get() else {
+            return false;
+        };
+
+        game_response.rated
+            && matches!(game_response.game_status, GameStatus::InProgress)
+            && game_response.time_mode == TimeMode::RealTime
+            && (Some(user.id) == Some(game_response.white_player.uid)
+                || Some(user.id) == Some(game_response.black_player.uid))
     };
-    let bottom_color = Color::Black;
-    let top_color = Color::White;
+
+    let game_resource = Resource::new(game_id, move |game_id| async move {
+        if let Some(game_id) = game_id {
+            get_game_from_nanoid(game_id).await
+        } else {
+            Err(leptos::prelude::ServerFnError::new("No game ID provided"))
+        }
+    });
 
     view! {
         <div class=move || {
             format!(
                 "pt-12 bg-board-dawn dark:bg-board-twilight {} {extend_tw_classes}",
-                parent_container_style(),
+                if vertical() {
+                    "flex flex-col h-full"
+                } else {
+                    "max-h-[100dvh] min-h-[100dvh] grid grid-cols-10  grid-rows-6 pr-1"
+                },
             )
         }>
-            <Show
-                when=vertical
-                fallback=move || {
-                    view! {
-                        <AnalysisInfo extend_tw_classes="absolute pl-4 pt-2 bg-board-dawn dark:bg-board-twilight" />
-                        <Board />
-                        <div class="flex flex-col col-span-2 row-span-6 p-1 h-full border-2 border-black select-none dark:border-white">
-                            <History />
-                        </div>
-                    }
-                }
-            >
+            <Suspense fallback=move || {
+                view! { <div>"Loading analysis..."</div> }
+            }>
+                {move || {
+                    let analysis_signal = match game_resource.get() {
+                        Some(Ok(game_response)) if !should_block_analysis(&game_response) => {
+                            let analysis_tree = AnalysisTree::from_game_response(
+                                &game_response,
+                                game_state,
+                                move_number.get_value(),
+                            );
+                            AnalysisSignal(RwSignal::new(LocalStorage::wrap(
+                                analysis_tree.unwrap_or_default(),
+                            )))
+                        }
+                        _ => {
+                            let analysis_tree = AnalysisTree::new_blank_analysis(game_state, GameType::MLP);
+                            AnalysisSignal(RwSignal::new(LocalStorage::wrap(analysis_tree)))
+                        }
+                    };
+                    provide_context(analysis_signal);
 
-                <div class="flex flex-col h-[85dvh]">
-                    <div class="flex flex-col flex-grow shrink">
-                        <div class="flex justify-between h-full max-h-16">
-                            <Reserve alignment=Alignment::SingleRow color=top_color />
-                        </div>
-                    </div>
-                    <AnalysisInfo />
-                    <Board />
-                    <div class="flex flex-col flex-grow shrink">
-                        <div class="flex justify-between h-full max-h-16">
-                            <Reserve alignment=Alignment::SingleRow color=bottom_color />
-                        </div>
-                    </div>
-                </div>
-                <History mobile=true />
-            </Show>
+                    view! {
+                        <Show
+                            when=vertical
+                            fallback=move || {
+                                view! {
+                                    <AnalysisInfo extend_tw_classes="absolute pl-4 pt-2 bg-board-dawn dark:bg-board-twilight" />
+                                    <Board />
+                                    <div class="flex flex-col col-span-2 row-span-6 p-1 h-full border-2 border-black select-none dark:border-white">
+                                        <History />
+                                    </div>
+                                }
+                            }
+                        >
+                            <div class="flex flex-col h-[85dvh]">
+                                <div class="flex flex-col flex-grow shrink">
+                                    <div class="flex justify-between h-full max-h-16">
+                                        <Reserve alignment=Alignment::SingleRow color=Color::White />
+                                    </div>
+                                </div>
+                                <AnalysisInfo />
+                                <Board />
+                                <div class="flex flex-col flex-grow shrink">
+                                    <div class="flex justify-between h-full max-h-16">
+                                        <Reserve alignment=Alignment::SingleRow color=Color::Black />
+                                    </div>
+                                </div>
+                            </div>
+                            <History mobile=true />
+                        </Show>
+                    }
+                }}
+            </Suspense>
         </div>
     }
 }
@@ -85,39 +139,41 @@ fn AnalysisInfo(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoV
     let analysis = expect_context::<AnalysisSignal>().0;
     let game_state = expect_context::<GameStateSignal>();
     let moves = move || {
-        let tree = &analysis().tree;
-        let current_node = analysis().current_node.clone();
-        let mut moves = Vec::new();
-        let sibling_nodes = current_node
-            .and_then(|n| tree.get_sibling_ids(&n.get_node_id(), false).ok())
-            .map_or(Vec::new(), |s| {
-                s.iter()
-                    .filter_map(|id| tree.get_node_by_id(id))
-                    .collect::<Vec<_>>()
-            });
-        for s in sibling_nodes {
-            let TreeNode {
-                turn,
-                piece,
-                position,
-            } = s.get_value().unwrap();
-            moves.push(
-                    view! {
-                        <div
-                            class="underline cursor-pointer no-link-style hover:text-pillbug-teal active:scale-95"
-                            on:click=move |_| {
-                                analysis
-                                    .update(|a| {
-                                        a.update_node(s.get_node_id(), Some(game_state));
-                                    })
-                            }
-                        >
-                            {format!("{turn}. {piece} {position}")}
-                        </div>
-                    }
-                );
-        }
-        moves.collect_view()
+        analysis.with(|a| {
+            let tree = &a.tree;
+            let mut moves = Vec::new();
+            let sibling_nodes = a.current_node
+                .as_ref()
+                .and_then(|n| tree.get_sibling_ids(&n.get_node_id(), false).ok())
+                .map_or(Vec::new(), |s| {
+                    s.iter()
+                        .filter_map(|id| tree.get_node_by_id(id))
+                        .collect::<Vec<_>>()
+                });
+            for s in sibling_nodes {
+                let TreeNode {
+                    turn,
+                    piece,
+                    position,
+                } = s.get_value().unwrap();
+                moves.push(
+                        view! {
+                            <div
+                                class="underline cursor-pointer no-link-style hover:text-pillbug-teal active:scale-95"
+                                on:click=move |_| {
+                                    analysis
+                                        .update(|a| {
+                                            a.update_node(s.get_node_id(), Some(game_state));
+                                        })
+                                }
+                            >
+                                {format!("{turn}. {piece} {position}")}
+                            </div>
+                        }
+                    );
+            }
+            moves.collect_view()
+        })
     };
     view! {
         <div class=extend_tw_classes>


### PR DESCRIPTION
1.Can now open analysis of games in a separate tab.

2.Just changing from hivegame.com/game/:nanoid to hivegame.com/analysis/:nanoid is enough to load the game in analysis.  This is prevented for relatime games if you are one of the players, it just loads a blank analysis in that case.

3.Also clones the large analysis tree structures less hopefully this helps with #508 
