### PR TITLE
Adds bot challenge creation endpoint

### DIFF
--- a/apis/src/main.rs
+++ b/apis/src/main.rs
@@ -19,7 +19,7 @@ cfg_if::cfg_if! { if #[cfg(feature = "ssr")] {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     use crate::websocket::{start_connection, WsServer};
-    use api::v1::bot::{games::{api_get_game, api_get_ongoing_games, api_get_pending_games}, play::api_play, challenges::{api_accept_challenge, api_get_challenges}};
+    use api::v1::bot::{games::{api_get_game, api_get_ongoing_games, api_get_pending_games}, play::api_play, challenges::{api_accept_challenge, api_create_challenge, api_get_challenges}};
     use api::v1::auth::get_token_handler::get_token;
     use api::v1::auth::get_identity_handler::get_identity;
     use api::v1::auth::jwt_secret::JwtSecret;
@@ -101,6 +101,7 @@ async fn main() -> std::io::Result<()> {
             .service(api_get_user)
             .service(api_get_challenges)
             .service(api_accept_challenge)
+            .service(api_create_challenge)
 
             // .leptos_routes(leptos_options.to_owned(), routes.to_owned(), App)
             .leptos_routes(routes.to_owned(), {


### PR DESCRIPTION
Closes #561 

Json with this stuff. 
It could be changed/simplified not sure all of them make sense to have, like the rating bands. Maybe even allowing correspondence is not needed. What do you think?

pub enum BotTimeControl {
    Untimed,
    RealTime { base: u32, increment: u32 }, //min sec
    Correspondence { mode: CorrespondenceMode, days: u32 }, // DaysPerMove or TotalTimeEach
}

pub struct BotChallengeRequest {
    pub game_type: GameType, // Base, MLP... base needs to be unrated
    pub visibility: ChallengeVisibility, //Public, Direct, Private (not sure private makes sense for bots)
    pub opponent: Option<String>, // Direct needs opponent Username
    pub color_choice: ColorChoice, // White, Black, Random
    pub time_control: BotTimeControl,
    pub rated: bool,
    pub band_upper: Option<i32>, //Min max rating
    pub band_lower: Option<i32>,
}