### PR TITLE
Adds bots own challenges to the api, refactors auth

### DIFF
--- a/apis/src/api/v1/auth/auth_.rs
+++ b/apis/src/api/v1/auth/auth_.rs
@@ -2,48 +2,75 @@ use super::jwt_secret::JwtSecret;
 use actix_web::{
     dev::Payload, error::InternalError, http::header, FromRequest, HttpRequest, HttpResponse,
 };
+use db_lib::{get_conn, models::User, DbPool};
 use serde_json::json;
-use std::future::{ready, Ready};
-pub struct Auth(pub String);
+use std::future::Future;
+use std::pin::Pin;
+pub struct Auth(pub User);
 use actix_web::web::Data;
+
+fn create_error_response(status: u16, message: &str) -> InternalError<String> {
+    let mut response = match status {
+        401 => HttpResponse::Unauthorized(),
+        400 => HttpResponse::BadRequest(),
+        _ => HttpResponse::InternalServerError(),
+    };
+
+    InternalError::from_response(
+        message.to_string(),
+        response.json(json!({
+          "success": false,
+          "data": {
+            "message": message
+          }
+        })),
+    )
+}
 
 impl FromRequest for Auth {
     type Error = InternalError<String>;
 
-    type Future = Ready<Result<Self, Self::Error>>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
         let access_token = req
             .headers()
             .get(header::AUTHORIZATION)
             .and_then(|value| value.to_str().ok())
-            .and_then(|str| str.split(" ").nth(1));
-        let jwt_secret = req.app_data::<Data<JwtSecret>>().unwrap();
+            .and_then(|str| str.split(" ").nth(1))
+            .map(|s| s.to_string());
 
-        match access_token {
-            Some(token) => match super::decode::jwt_decode(token, &jwt_secret.decoding) {
-                Ok(email) => ready(Ok(Auth(email))),
+        let jwt_secret = req.app_data::<Data<JwtSecret>>().cloned();
+        let pool = req.app_data::<Data<DbPool>>().cloned();
 
-                Err(e) => ready(Err(InternalError::from_response(
-                    e.to_string(),
-                    HttpResponse::Unauthorized().json(json!({
-                      "success": false,
-                      "data": {
-                        "message": e.to_string(),
-                      }
-                    })),
-                ))),
-            },
+        Box::pin(async move {
+            let token =
+                access_token.ok_or_else(|| create_error_response(401, "No token provided"))?;
+            let jwt_secret =
+                jwt_secret.ok_or_else(|| create_error_response(500, "Internal server error"))?;
+            let pool = pool.ok_or_else(|| create_error_response(500, "Internal server error"))?;
 
-            None => ready(Err(InternalError::from_response(
-                String::from("No token provided"),
-                HttpResponse::Unauthorized().json(json!({
-                  "success": false,
-                  "data": {
-                    "message": "No token provided"
-                  }
-                })),
-            ))),
-        }
+            let email = super::decode::jwt_decode(&token, &jwt_secret.decoding)
+                .map_err(|e| create_error_response(401, &e.to_string()))?;
+
+            let mut conn = get_conn(&pool)
+                .await
+                .map_err(|_| create_error_response(500, "Database connection error"))?;
+
+            let user_result = User::find_by_email(&email, &mut conn).await;
+            let user = if let Ok(user) = user_result {
+                user
+            } else {
+                User::find_by_username(&email, &mut conn)
+                    .await
+                    .map_err(|_| create_error_response(400, "User not found"))?
+            };
+
+            if !user.bot {
+                return Err(create_error_response(401, "Not a bot"));
+            }
+
+            Ok(Auth(user))
+        })
     }
 }

--- a/apis/src/api/v1/auth/get_identity_handler.rs
+++ b/apis/src/api/v1/auth/get_identity_handler.rs
@@ -4,11 +4,12 @@ use actix_web::HttpResponse;
 use serde_json::json;
 
 #[get("/api/v1/auth/id")]
-pub async fn get_identity(Auth(email): Auth) -> HttpResponse {
+pub async fn get_identity(Auth(bot): Auth) -> HttpResponse {
     HttpResponse::Ok().json(json!({
       "success": true,
       "data": {
-        "bot": email,
+        "bot": bot.email,
+        "user_id": bot.id
       }
     }))
 }

--- a/apis/src/api/v1/bot/users.rs
+++ b/apis/src/api/v1/bot/users.rs
@@ -11,13 +11,22 @@ use serde_json::json;
 use uuid::Uuid;
 
 #[get("/api/v1/bot/user/{id}")]
-pub async fn api_get_user(id: Path<Uuid>, Auth(email): Auth, pool: Data<DbPool>) -> HttpResponse {
+pub async fn api_get_user(id: Path<Uuid>, Auth(bot): Auth, pool: Data<DbPool>) -> HttpResponse {
     let id = id.into_inner();
+    if id == bot.id {
+        return HttpResponse::Ok().json(json!({
+          "success": true,
+          "data": {
+            "bot": bot.email,
+            "user": bot,
+          }
+        }));
+    }
     match get_user(id, pool).await {
         Ok(user) => HttpResponse::Ok().json(json!({
           "success": true,
           "data": {
-            "bot": email,
+            "bot": bot.email,
             "user": user,
           }
         })),


### PR DESCRIPTION
Refactored bot API authentication to centralize user lookup in the Auth middleware, eliminating redundant database calls and improving code maintainability. 😆 Also adds bots own open challenges to get_challenges. Closes #579 Closes #594 