### PR TITLE
Adds control api endpoint, prevents self play

### DIFF
--- a/apis/src/api/v1/bot/challenges.rs
+++ b/apis/src/api/v1/bot/challenges.rs
@@ -253,7 +253,7 @@ async fn accept_challenge(
             }
         }
     };
-    let new_game = NewGame::new(white_id, black_id, &challenge);
+    let new_game = NewGame::new(white_id, black_id, &challenge)?;
     let (game, deleted_challenges) =
         Game::create_and_delete_challenges(new_game, &mut conn).await?;
 

--- a/apis/src/api/v1/bot/play.rs
+++ b/apis/src/api/v1/bot/play.rs
@@ -1,5 +1,5 @@
 use crate::api::v1::auth::Auth;
-use crate::api::v1::messages::send::send_messages;
+use crate::api::v1::messages::send::{send_control_messages, send_turn_messages};
 use crate::websocket::WsServer;
 use actix::Addr;
 use actix_web::web::{Data, Json};
@@ -12,7 +12,7 @@ use db_lib::{
 };
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::AsyncConnection;
-use hive_lib::{Piece, Position, State, Turn};
+use hive_lib::{Color, GameControl, Piece, Position, State, Turn};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use shared_types::GameId;
@@ -22,6 +22,12 @@ use std::str::FromStr;
 struct PlayRequest {
     game_id: GameId,
     piece_pos: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ControlRequest {
+    game_id: GameId,
+    control: String,
 }
 
 #[post("/api/v1/bot/games/play")]
@@ -88,7 +94,7 @@ async fn play_move(
             async move {
                 state.play_turn_from_position(piece, position)?;
                 let updated_game = game.update_gamestate(&state, 0_f64, tc).await?;
-                send_messages(
+                send_turn_messages(
                     ws_server.clone(),
                     &updated_game,
                     &bot,
@@ -123,4 +129,109 @@ async fn play_move(
         })
         .await?;
     Ok((game, played_turn_out))
+}
+
+#[post("/api/v1/bot/games/control")]
+pub async fn api_control(
+    Json(req): Json<ControlRequest>,
+    Auth(bot): Auth,
+    pool: Data<DbPool>,
+    ws_server: Data<Addr<WsServer>>,
+) -> HttpResponse {
+    match handle_control(req, bot.clone(), pool, ws_server).await {
+        Ok(game) => HttpResponse::Ok().json(json!({
+          "success": true,
+          "data": {
+            "bot": bot.email,
+            "bot_username": bot.username,
+            "game_id": game.nanoid,
+            "finished": game.finished,
+          }
+        })),
+        Err(e) => HttpResponse::Ok().json(json!({
+          "success": false,
+          "data": {
+            "error": e.to_string(),
+          }
+        })),
+    }
+}
+
+async fn handle_control(
+    req: ControlRequest,
+    bot: User,
+    pool: Data<DbPool>,
+    ws_server: Data<Addr<WsServer>>,
+) -> Result<Game> {
+    let cloned_pool = pool.clone();
+    let mut conn = get_conn(&cloned_pool).await?;
+    let game = Game::find_by_game_id(&req.game_id, &mut conn).await?;
+
+    if game.finished {
+        return Err(anyhow!("Game is finished"));
+    }
+
+    let bot_color = if game.white_id == bot.id {
+        Color::White
+    } else if game.black_id == bot.id {
+        Color::Black
+    } else {
+        return Err(anyhow!("Not your game"));
+    };
+
+    let game_control = match req.control.as_str() {
+        "resign" => {
+            if game.turn < 2 {
+                return Err(anyhow!("Cannot resign before turn 2"));
+            }
+            GameControl::Resign(bot_color)
+        }
+        "abort" => {
+            if game.turn >= 2 {
+                return Err(anyhow!("Cannot abort after turn 2"));
+            }
+            if game.tournament_id.is_some() {
+                return Err(anyhow!("Cannot abort tournament games"));
+            }
+            GameControl::Abort(bot_color)
+        }
+        _ => return Err(anyhow!("Invalid control type: {}", req.control)),
+    };
+
+    if let Some(last_control) = game.last_game_control() {
+        if last_control == game_control {
+            return Err(anyhow!("Control already sent"));
+        }
+    }
+
+    let updated_game = conn
+        .transaction::<_, anyhow::Error, _>(move |tc| {
+            async move {
+                let result_game = match game_control {
+                    GameControl::Resign(_) => game.resign(&game_control, tc).await?,
+                    GameControl::Abort(_) => {
+                        game.delete(tc).await?;
+                        let mut game_copy = game.clone();
+                        game_copy.finished = true;
+                        game_copy
+                    }
+                    _ => unreachable!(),
+                };
+
+                send_control_messages(
+                    ws_server.clone(),
+                    &result_game,
+                    &bot,
+                    &pool,
+                    game_control.clone(),
+                )
+                .await?;
+
+                Ok(result_game)
+            }
+            .scope_boxed()
+        })
+        .await?;
+
+    Ok(updated_game)
 }

--- a/apis/src/main.rs
+++ b/apis/src/main.rs
@@ -19,7 +19,7 @@ cfg_if::cfg_if! { if #[cfg(feature = "ssr")] {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     use crate::websocket::{start_connection, WsServer};
-    use api::v1::bot::{games::{api_get_game, api_get_ongoing_games, api_get_pending_games}, play::api_play, challenges::{api_accept_challenge, api_create_challenge, api_get_challenges}};
+    use api::v1::bot::{games::{api_get_game, api_get_ongoing_games, api_get_pending_games}, play::{api_control, api_play}, challenges::{api_accept_challenge, api_create_challenge, api_get_challenges}};
     use api::v1::auth::get_token_handler::get_token;
     use api::v1::auth::get_identity_handler::get_identity;
     use api::v1::auth::jwt_secret::JwtSecret;
@@ -95,6 +95,7 @@ async fn main() -> std::io::Result<()> {
             .service(get_token)
             .service(get_identity)
             .service(api_play)
+            .service(api_control)
             .service(api_get_game)
             .service(api_get_ongoing_games)
             .service(api_get_pending_games)

--- a/apis/src/websocket/server_handlers/challenges/accept.rs
+++ b/apis/src/websocket/server_handlers/challenges/accept.rs
@@ -82,7 +82,7 @@ impl AcceptHandler {
         let (game, deleted_challenges, game_response) = conn
             .transaction::<_, anyhow::Error, _>(move |tc| {
                 async move {
-                    let new_game = NewGame::new(white_id, black_id, &challenge);
+                    let new_game = NewGame::new(white_id, black_id, &challenge)?;
                     let (game, deleted_challenges) =
                         Game::create_and_delete_challenges(new_game, tc).await?;
                     let game_response = GameResponse::from_model(&game, tc).await?;

--- a/db/src/db_error.rs
+++ b/db/src/db_error.rs
@@ -7,11 +7,11 @@ pub enum DbError {
     NotEnoughPlayers,
     #[error("Tournament is full")]
     TournamentFull,
-    #[error("Internal database error")]
+    #[error("Cannot join an invite only tournament")]
     TournamentInviteOnly,
     #[error("Invalid TournamentDetails")]
     InvalidTournamentDetails { info: String },
-    #[error("Cannot join an invite only tournament")]
+    #[error("Internal database error")]
     InternalError,
     #[error("Invalid input")]
     InvalidInput { info: String, error: String },

--- a/db/src/models/game.rs
+++ b/db/src/models/game.rs
@@ -140,7 +140,14 @@ impl NewGame {
         }
     }
 
-    pub fn new(white: Uuid, black: Uuid, challenge: &Challenge) -> Self {
+    pub fn new(white: Uuid, black: Uuid, challenge: &Challenge) -> Result<Self, DbError> {
+        if white == black {
+            return Err(DbError::InvalidInput {
+                info: "You can't play here with yourself.".to_string(),
+                error: String::new(),
+            });
+        }
+
         let time_left = match TimeMode::from_str(&challenge.time_mode).unwrap() {
             TimeMode::Untimed => None,
             TimeMode::RealTime => challenge
@@ -153,7 +160,7 @@ impl NewGame {
             },
         };
 
-        Self {
+        Ok(Self {
             nanoid: challenge.nanoid.to_owned(),
             current_player_id: white,
             black_id: black,
@@ -186,7 +193,7 @@ impl NewGame {
             tournament_game_result: TournamentGameResult::Unknown.to_string(),
             game_start: GameStart::Moves.to_string(),
             move_times: vec![],
-        }
+        })
     }
 }
 


### PR DESCRIPTION
Closes #601
Closes #599

Allows bots to abort and resign games.
Prevents bots playing themselves.
Refactors message sending from bot api.
Fixes switched error messages.