### PR TITLE
feat: add opponent username filter in games filter

### DIFF
--- a/apis/src/components/organisms/display_games.rs
+++ b/apis/src/components/organisms/display_games.rs
@@ -51,6 +51,7 @@ pub fn DisplayGames(tab_view: GameProgress) -> impl IntoView {
                         expansions: base_filters.expansions,
                         rated: base_filters.rated,
                         exclude_bots: base_filters.exclude_bots,
+                        opponent: base_filters.opponent,
                     });
 
                     ctx.has_more.set_value(true);

--- a/apis/src/providers/games_search_context.rs
+++ b/apis/src/providers/games_search_context.rs
@@ -21,6 +21,7 @@ pub struct FilterState {
     pub expansions: Option<bool>,
     pub rated: Option<bool>,
     pub exclude_bots: bool,
+    pub opponent: Option<String>,
 }
 
 impl Default for FilterState {
@@ -32,6 +33,7 @@ impl Default for FilterState {
             expansions: None,    // Show both Base and MLP games by default
             rated: None,         // Show both rated and unrated
             exclude_bots: false, // Don't exclude bots by default
+            opponent: None,
         }
     }
 }
@@ -84,10 +86,11 @@ pub fn load_games(
         color: filters.color,
         result: filters.result,
     });
+    let player2 = filters.opponent.clone().map(|username| PlayerFilter { username, color: None, result: None });
 
     let options = GamesQueryOptions {
         player1,
-        player2: None,
+        player2,
         speeds: filters.speeds,
         current_batch: batch_info,
         batch_size,


### PR DESCRIPTION
This PR adds opponent username filter via a string input in profile page's game filter.

#603 

<img width="406" height="486" alt="Captura de Tela 2025-09-14 às 09 39 33" src="https://github.com/user-attachments/assets/224452c9-83e8-47a4-a0f1-ccb7a6e5b84e" />
