### PR TITLE
remove client side check from timer becoming red on timeout

### DIFF
--- a/apis/src/components/molecules/live_timer.rs
+++ b/apis/src/components/molecules/live_timer.rs
@@ -142,7 +142,7 @@ pub fn LiveTimer(side: Signal<Color>) -> impl IntoView {
             class=move || {
                 format!(
                     "flex resize h-full select-none items-center justify-center text-xl md:text-2xl lg:text-4xl {}",
-                    if time_is_zero() || timed_out() { "bg-ladybug-red" } else { "" },
+                    if timed_out() { "bg-ladybug-red" } else { "" },
                 )
             }
         >


### PR DESCRIPTION
As discussed in [here](https://discord.com/channels/1194638121866907769/1421935294663491654/1421935294663491654), there's no necessity in two signals here: by keeping the one coming from server we avoid the confusion when player sees the opponent's timeout coming from client but later sees that server didn't register.

Tested locally a few times, visually seems to work just fine, not sure how to properly test since it's the matter of less than a second.