### PR TITLE
Switches scroll zoom back, fixes clippy warnings

### DIFF
--- a/apis/src/components/atoms/rating_history.rs
+++ b/apis/src/components/atoms/rating_history.rs
@@ -2,13 +2,13 @@ use crate::{
     components::layouts::base_layout::OrientationSignal,
     functions::games::get::get_rating_history_resource, responses::RatingHistoryResponse,
 };
+use chrono::{DateTime, Duration, Utc};
 use leptos::prelude::*;
 use leptos_chartistry::*;
+use leptos_meta::Style;
 use leptos_use::use_window_size;
 use shared_types::GameSpeed;
 use uuid::Uuid;
-use leptos_meta::Style;
-use chrono::{Duration, DateTime, Utc};
 
 fn build_x_ticks(data: ReadSignal<Vec<RatingHistoryResponse>>) -> TickLabels<DateTime<Utc>> {
     let data_vec = data.get();
@@ -34,11 +34,16 @@ pub fn RatingGraph(user_id: Uuid, game_speed: GameSpeed) -> impl IntoView {
     let vertical = expect_context::<OrientationSignal>().orientation_vertical;
     let history = OnceResource::new(get_rating_history_resource(user_id, game_speed));
     let window_size = use_window_size();
-    let padding_right = Signal::derive(move || window_size.width.get() * if vertical.get() { 0.01 } else { 0.06 });
-    let padding_left = Signal::derive(move || window_size.width.get() * if vertical.get() { 0.01 } else { 0.03 });
-    let padding_bottom = Signal::derive(move || window_size.height.get() * if vertical.get() { 0.04 } else { 0.07 });
-    let graph_width = Signal::derive(move || window_size.width.get() * if vertical.get() { 0.83 } else { 0.82 });
-    let graph_height = Signal::derive(move || window_size.height.get() * 0.58 - padding_bottom.get());
+    let padding_right =
+        Signal::derive(move || window_size.width.get() * if vertical.get() { 0.01 } else { 0.06 });
+    let padding_left =
+        Signal::derive(move || window_size.width.get() * if vertical.get() { 0.01 } else { 0.03 });
+    let padding_bottom =
+        Signal::derive(move || window_size.height.get() * if vertical.get() { 0.04 } else { 0.07 });
+    let graph_width =
+        Signal::derive(move || window_size.width.get() * if vertical.get() { 0.83 } else { 0.82 });
+    let graph_height =
+        Signal::derive(move || window_size.height.get() * 0.58 - padding_bottom.get());
 
     view! {
         <div
@@ -78,7 +83,7 @@ pub fn RatingGraph(user_id: Uuid, game_speed: GameSpeed) -> impl IntoView {
                                         x_periods.with_strftime("%Y-%m-%d"),
                                     );
                                     tooltip.y_ticks = TickLabels::aligned_floats()
-                                        .with_format(|value, _| format!("{:.0}", value));
+                                        .with_format(|value, _| format!("{value:.0}"));
                                     view! {
                                         <Style>
                                             "

--- a/db/src/models/tournament.rs
+++ b/db/src/models/tournament.rs
@@ -661,7 +661,7 @@ impl Tournament {
 
         // if odd number of players, add a bye player
         let bye_player = User::find_by_username("SwissByePlayer", conn).await?;
-        if players.len() % 2 != 0 && !players.iter().any(|p| p.id == bye_player.id) {
+        if !players.len().is_multiple_of(2) && !players.iter().any(|p| p.id == bye_player.id) {
             self.join(&bye_player.id, conn).await?;
             players.push(bye_player.clone());
         };


### PR DESCRIPTION
In #620 I accidentally switched around mouswheel zoom. This fixes that and a couple of clippy warnings.