### PR TITLE
extend Swiss tournament to 64 players; add autoskip bye player 1st round

### DIFF
--- a/apis/src/pages/tournament_create.rs
+++ b/apis/src/pages/tournament_create.rs
@@ -224,6 +224,18 @@ pub fn TournamentCreate() -> impl IntoView {
     let is_not_preview_desc = RwSignal::new(true);
     let markdown_desc = move || markdown_to_html(&tournament.description.get());
 
+    let max_seats = Signal::derive(move || {
+        match tournament.mode.get() {
+            TournamentMode::DoubleSwiss => 64,
+            _ => 16,
+        }
+    });
+    Effect::new(move || {
+        let current_max = max_seats.get();
+        if tournament.seats.get() > current_max {
+            tournament.seats.set(current_max);
+        }
+    });
     view! {
         <div class="flex justify-center items-center pt-10">
             <div class="container flex flex-col justify-between p-2 md:flex-row md:flex-wrap">
@@ -300,7 +312,7 @@ pub fn TournamentCreate() -> impl IntoView {
                             signal_to_update=tournament.seats
                             name="Min Seats"
                             min=tournament.min_seats
-                            max=16
+                            max=max_seats
                             step=1
                         /> {tournament.seats}
                     </div>


### PR DESCRIPTION
- Extend Swiss to 64 players since apparently we're popular
- And since we're on it, in the previous diff only added the autoskip for the Bye player to the next rounds, so first round was manual.

Would appreciate much if this can be shipped before Sunday to help Frasco out but if not he can handle

Creation:

<img width="1667" height="758" alt="image" src="https://github.com/user-attachments/assets/5074c9cf-1eb7-45c7-bea2-3442ba3b2d0c" />

Created in the Future section:

<img width="1301" height="271" alt="image" src="https://github.com/user-attachments/assets/e7b4b91b-e870-4b74-a6d7-b05d87c8a358" />

Skipped Bye player when odd number of players:

<img width="1331" height="827" alt="image" src="https://github.com/user-attachments/assets/01c2c483-8ed8-44f6-a1e6-e6b1e864fbd9" />

