### PR TITLE
Replace the bot icon with "BOT"

### DIFF
--- a/apis/src/components/atoms/profile_link.rs
+++ b/apis/src/components/atoms/profile_link.rs
@@ -38,7 +38,7 @@ pub fn ProfileLink(
                     {username} <Show when=patreon>
                         <Icon icon=icondata_lu::LuCrown attr:class="size-2" />
                     </Show> <Show when=bot>
-                        <Icon icon=icondata_mdi::MdiRobotHappy attr:class="size-3" />
+                        <span class="text-[80%] ml-1">BOT</span>
                     </Show>
                 </div>
             </a>


### PR DESCRIPTION
The goal here is to replace the bot icon which is not understandable.

Before:
<img width="116" height="34" alt="image" src="https://github.com/user-attachments/assets/d9551589-b7ae-44d4-98b4-66497b827960" />

After:
<img width="117" height="43" alt="image" src="https://github.com/user-attachments/assets/aca1ec1f-30fe-466f-96dc-deee358b4de2" />

I made this PR without compiling for now. If it is agreed upon, I'll take the time to test it properly
