### PR TITLE
Adds mass adjudicate/undo, fixes bug with unadjudicating a game

### DIFF
--- a/apis/src/api/v1/bot/play.rs
+++ b/apis/src/api/v1/bot/play.rs
@@ -224,14 +224,8 @@ async fn handle_control(
                     _ => unreachable!(),
                 };
 
-                send_control_messages(
-                    ws_server.clone(),
-                    &result_game,
-                    &bot,
-                    &pool,
-                    game_control.clone(),
-                )
-                .await?;
+                send_control_messages(ws_server.clone(), &result_game, &bot, &pool, game_control)
+                    .await?;
 
                 Ok(result_game)
             }

--- a/apis/src/common/tournament_action.rs
+++ b/apis/src/common/tournament_action.rs
@@ -13,6 +13,8 @@ pub enum TournamentAction {
     Abandon(TournamentId),
     // TODO: AddToSeries(TournamentId),
     AdjudicateResult(GameId, TournamentGameResult),
+    DoubleForfeitUnstartedGames(TournamentId),
+    ResetAdjudicatedGames(TournamentId),
     Create(Box<TournamentDetails>),
     Delete(TournamentId),
     Finish(TournamentId),

--- a/apis/src/components/atoms/gc_button.rs
+++ b/apis/src/components/atoms/gc_button.rs
@@ -51,7 +51,7 @@ pub fn ConfirmButton(
     #[prop(optional, into)] hidden: Signal<bool>,
 ) -> impl IntoView {
     let game_state = expect_context::<GameStateSignal>();
-    let pending_slice = create_read_slice(game_state.signal, |gs| gs.game_control_pending.clone());
+    let pending_slice = create_read_slice(game_state.signal, |gs| gs.game_control_pending);
     let turn = create_read_slice(game_state.signal, |gs| gs.state.turn as i32);
     let (icon, title) = get_icon_and_title(game_control);
     let color = game_control.color();

--- a/apis/src/components/molecules/control_buttons.rs
+++ b/apis/src/components/molecules/control_buttons.rs
@@ -32,7 +32,7 @@ pub fn ControlButtons() -> impl IntoView {
             .get()
             .expect("User_id is one of the players in this game")
     });
-    let pending = create_read_slice(game_state.signal, |gs| gs.game_control_pending.clone());
+    let pending = create_read_slice(game_state.signal, |gs| gs.game_control_pending);
     let not_tournament = create_read_slice(game_state.signal, |gs| {
         gs.game_response
             .as_ref()

--- a/apis/src/components/molecules/unplayed_game_row.rs
+++ b/apis/src/components/molecules/unplayed_game_row.rs
@@ -149,7 +149,10 @@ pub fn UnplayedGameRow(
                                 format!("Adjudicated result: {}", game.tournament_game_result)
                             })}
                     </Show>
-                    <Show when=move || user_is_organizer() && !tournament_finished()>
+                    <Show when=move || {
+                        user_is_organizer() && !tournament_finished()
+                            && game.with_value(|game| game.organizer_can_adjudicate())
+                    }>
                         <button class=BUTTON_STYLE on:click=toggle_adjudicate>
                             {"Adjudicate"}
                         </button>

--- a/apis/src/components/organisms/reserve.rs
+++ b/apis/src/components/organisms/reserve.rs
@@ -143,9 +143,9 @@ pub fn Reserve(
 
                 let mut clicked_position = None;
                 let active_color = move_info.active.as_ref().map(|(piece, _)| piece.color());
-                if active_color == Some(reserve_color) {
-                    clicked_position = move_info.reserve_position;
-                } else if !analysis && user_color().is_some_and(|uc| uc == reserve_color) {
+                if active_color == Some(reserve_color)
+                    || (!analysis && user_color() == Some(reserve_color))
+                {
                     clicked_position = move_info.reserve_position;
                 }
 

--- a/apis/src/main.rs
+++ b/apis/src/main.rs
@@ -54,11 +54,8 @@ async fn main() -> std::io::Result<()> {
     conn.run_pending_migrations(MIGRATIONS)
         .expect("Ran migrations");
 
-    let hash: [u8; 64] = Sha512::digest(&config.session_secret)
-        .as_slice()
-        .try_into()
-        .expect("Wrong size");
-    let cookie_key = Key::from(&hash);
+    let hash = Sha512::digest(&config.session_secret);
+    let cookie_key = Key::from(hash.as_ref());
     let pool = get_pool(&config.database_url)
         .await
         .expect("Failed to get pool");

--- a/apis/src/pages/play.rs
+++ b/apis/src/pages/play.rs
@@ -144,7 +144,7 @@ pub fn Play() -> impl IntoView {
                     if let Some((_turn, gc)) = game.game_control_history.last() {
                         match gc {
                             GameControl::DrawOffer(_) | GameControl::TakebackRequest(_) => {
-                                game_state.set_pending_gc(gc.clone())
+                                game_state.set_pending_gc(*gc)
                             }
                             _ => {}
                         }
@@ -214,7 +214,7 @@ pub fn Play() -> impl IntoView {
                             }
                         }
                         GameReaction::Control(game_control) => {
-                            game_state.set_pending_gc(game_control.clone());
+                            game_state.set_pending_gc(game_control);
 
                             match game_control {
                                 GameControl::DrawAccept(_) => {

--- a/apis/src/pages/tournament.rs
+++ b/apis/src/pages/tournament.rs
@@ -26,7 +26,6 @@ use leptos::prelude::*;
 use leptos_router::hooks::{use_navigate, use_params_map};
 use leptos_use::core::ConnectionReadyState;
 use shared_types::{
-    Conclusion,
     GameSpeed,
     PrettyString,
     TimeInfo,
@@ -267,11 +266,7 @@ fn LoadedTournament(tournament: TournamentResponse) -> impl IntoView {
         let mut result = tournament.with_value(|t| {
             t.games
                 .iter()
-                .filter(|g| {
-                    g.conclusion == Conclusion::Unknown
-                        || g.conclusion == Conclusion::Committee
-                        || g.conclusion == Conclusion::Forfeit
-                })
+                .filter(|g| g.organizer_can_adjudicate())
                 .cloned()
                 .collect::<Vec<GameResponse>>()
         });
@@ -283,6 +278,54 @@ fn LoadedTournament(tournament: TournamentResponse) -> impl IntoView {
             .iter()
             .any(|e| e.tournament_game_result == TournamentGameResult::Unknown)
     });
+    let unstarted_games_count = Signal::derive(move || {
+        tournament.with_value(|t| {
+            t.games
+                .iter()
+                .filter(|g| g.game_status == GameStatus::NotStarted)
+                .count()
+        })
+    });
+    let adjudicated_games_count = Signal::derive(move || {
+        tournament.with_value(|t| {
+            t.games
+                .iter()
+                .filter(|g| g.game_status == GameStatus::Adjudicated)
+                .count()
+        })
+    });
+    let confirming_double_forfeit = RwSignal::new(false);
+    let confirming_reset_adjudicated = RwSignal::new(false);
+    let unstarted_games_label = move || {
+        let nr = unstarted_games_count();
+        if nr == 1 {
+            String::from("1 unstarted game")
+        } else {
+            format!("{nr} unstarted games")
+        }
+    };
+    let request_double_forfeit = move |_| {
+        if user_is_organizer_or_admin() && inprogress {
+            confirming_double_forfeit.set(true);
+        }
+    };
+    let cancel_double_forfeit = move |_| confirming_double_forfeit.set(false);
+    let double_forfeit_unstarted = move |_| {
+        if user_is_organizer_or_admin() && inprogress {
+            send_action(TournamentAction::DoubleForfeitUnstartedGames(
+                tournament_id.get_value(),
+            ));
+            confirming_double_forfeit.set(false);
+        }
+    };
+    let reset_adjudicated = move |_| {
+        if user_is_organizer_or_admin() && inprogress {
+            send_action(TournamentAction::ResetAdjudicatedGames(
+                tournament_id.get_value(),
+            ));
+            confirming_reset_adjudicated.set(false);
+        }
+    };
     let unplayed_games_string = move || {
         let nr = unplayed_games.with_value(|games| games.len());
         if nr == 1 {
@@ -476,9 +519,9 @@ fn LoadedTournament(tournament: TournamentResponse) -> impl IntoView {
                         tournament
                     />
                 </Show>
-                <Show when=user_is_organizer_or_admin>
-                    <div class="flex gap-1 justify-center items-center p-2">
-                        <Show when=move || inprogress>
+                <Show when=move || user_is_organizer_or_admin() && inprogress>
+                    <div class="flex flex-col gap-2 justify-center items-center p-2">
+                        <div class="flex gap-1 justify-center items-center">
                             <button
                                 class=BUTTON_STYLE
                                 on:click=finish
@@ -486,6 +529,92 @@ fn LoadedTournament(tournament: TournamentResponse) -> impl IntoView {
                             >
                                 {"Finish"}
                             </button>
+                        </div>
+                        <Show when=move || { unstarted_games_count() > 0 }>
+                            <div class="flex flex-col gap-2 items-center p-2 rounded">
+                                <p class="text-sm font-semibold text-center">
+                                    {move || {
+                                        format!(
+                                            "{} will be double forfeited.",
+                                            unstarted_games_label(),
+                                        )
+                                    }}
+                                </p>
+                                <Show
+                                    when=move || confirming_double_forfeit()
+                                    fallback=move || {
+                                        view! {
+                                            <button class=BUTTON_STYLE on:click=request_double_forfeit>
+                                                "Double forfeit unstarted games"
+                                            </button>
+                                        }
+                                    }
+                                >
+                                    <div class="flex flex-col gap-2 items-center">
+                                        <div class="text-sm text-center">
+                                            {"This will adjudicate every unstarted tournament game as a double forfeit."}
+                                        </div>
+                                        <div class="flex gap-2">
+                                            <button
+                                                class="flex justify-center items-center py-2 px-4 font-bold text-white rounded active:scale-95 bg-ladybug-red dark:hover:bg-pillbug-teal hover:bg-pillbug-teal"
+                                                on:click=double_forfeit_unstarted
+                                            >
+                                                {move || format!("Confirm {}", unstarted_games_label())}
+                                            </button>
+                                            <button class=BUTTON_STYLE on:click=cancel_double_forfeit>
+                                                {"Cancel"}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </Show>
+                            </div>
+                        </Show>
+                        <Show when=move || { adjudicated_games_count() > 0 }>
+                            <div class="flex flex-col gap-2 items-center p-2 rounded">
+                                <p class="text-sm font-semibold text-center">
+                                    {move || {
+                                        let count = adjudicated_games_count();
+                                        if count == 1 {
+                                            String::from("1 adjudicated game will be reset.")
+                                        } else {
+                                            format!("{count} adjudicated games will be reset.")
+                                        }
+                                    }}
+                                </p>
+                                <Show
+                                    when=move || confirming_reset_adjudicated()
+                                    fallback=move || {
+                                        view! {
+                                            <button
+                                                class=BUTTON_STYLE
+                                                on:click=move |_| confirming_reset_adjudicated.set(true)
+                                            >
+                                                "Undo adjudications"
+                                            </button>
+                                        }
+                                    }
+                                >
+                                    <div class="flex flex-col gap-2 items-center">
+                                        <div class="text-sm text-center">
+                                            {"This will set all adjudicated tournament games back to not started."}
+                                        </div>
+                                        <div class="flex gap-2">
+                                            <button
+                                                class="flex justify-center items-center py-2 px-4 font-bold text-white rounded active:scale-95 bg-ladybug-red dark:hover:bg-pillbug-teal hover:bg-pillbug-teal"
+                                                on:click=reset_adjudicated
+                                            >
+                                                {"Confirm undo"}
+                                            </button>
+                                            <button
+                                                class=BUTTON_STYLE
+                                                on:click=move |_| confirming_reset_adjudicated.set(false)
+                                            >
+                                                {"Cancel"}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </Show>
+                            </div>
                         </Show>
                     </div>
                 </Show>

--- a/apis/src/responses/game.rs
+++ b/apis/src/responses/game.rs
@@ -114,6 +114,19 @@ impl GameResponse {
         .expect("State to be valid, as game was")
     }
 
+    pub fn organizer_can_adjudicate(&self) -> bool {
+        matches!(
+            self.conclusion,
+            Conclusion::Unknown | Conclusion::Committee | Conclusion::Forfeit
+        ) && self.turn == 0
+            && self.history.is_empty()
+            && self.game_start == GameStart::Ready
+            && matches!(
+                self.game_status,
+                GameStatus::NotStarted | GameStatus::Adjudicated
+            )
+    }
+
     pub fn time_left(&self) -> Result<std::time::Duration> {
         if self.turn < 2 {
             return Ok(std::time::Duration::from_nanos(u64::MAX));

--- a/apis/src/websocket/client_handlers/game/handler.rs
+++ b/apis/src/websocket/client_handlers/game/handler.rs
@@ -51,9 +51,7 @@ fn handle_reaction(gar: GameActionResponse) {
             // TODO: Do we want anything here?
         }
 
-        GameReaction::Control(ref game_control) => {
-            handle_control(game_control.clone(), gar.clone())
-        }
+        GameReaction::Control(ref game_control) => handle_control(*game_control, gar.clone()),
         GameReaction::Started => {
             update_notifier.game_response.set(Some(gar.clone()));
         }

--- a/apis/src/websocket/server_handlers/game/control_handler.rs
+++ b/apis/src/websocket/server_handlers/game/control_handler.rs
@@ -62,7 +62,7 @@ impl GameControlHandler {
             message: ServerMessage::Game(Box::new(GameUpdate::Reaction(GameActionResponse {
                 game_id: GameId(self.game.nanoid.to_owned()),
                 game: game_response.clone(),
-                game_action: GameReaction::Control(self.control.clone()),
+                game_action: GameReaction::Control(self.control),
                 user_id: self.user_id.to_owned(),
                 username: self.username.to_owned(),
             }))),

--- a/apis/src/websocket/server_handlers/tournaments/bulk_adjudicate.rs
+++ b/apis/src/websocket/server_handlers/tournaments/bulk_adjudicate.rs
@@ -1,0 +1,70 @@
+use crate::{
+    common::{ServerMessage, TournamentUpdate},
+    websocket::messages::{InternalServerMessage, MessageDestination},
+};
+use anyhow::Result;
+use db_lib::{get_conn, models::Tournament, DbPool};
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
+use shared_types::TournamentId;
+use uuid::Uuid;
+
+pub enum BulkAdjudication {
+    DoubleForfeitUnstarted,
+    ResetAdjudicated,
+}
+
+pub struct BulkAdjudicateHandler {
+    tournament_id: TournamentId,
+    user_id: Uuid,
+    pool: DbPool,
+    action: BulkAdjudication,
+}
+
+impl BulkAdjudicateHandler {
+    pub async fn new(
+        tournament_id: TournamentId,
+        user_id: Uuid,
+        action: BulkAdjudication,
+        pool: &DbPool,
+    ) -> Result<Self> {
+        Ok(Self {
+            tournament_id,
+            user_id,
+            pool: pool.clone(),
+            action,
+        })
+    }
+
+    pub async fn handle(&self) -> Result<Vec<InternalServerMessage>> {
+        let mut conn = get_conn(&self.pool).await?;
+        let tournament = Tournament::find_by_tournament_id(&self.tournament_id, &mut conn).await?;
+
+        conn.transaction::<_, anyhow::Error, _>(move |tc| {
+            let tournament = tournament.clone();
+            let user_id = self.user_id;
+            let action = &self.action;
+            async move {
+                match action {
+                    BulkAdjudication::DoubleForfeitUnstarted => {
+                        tournament
+                            .double_forfeit_unstarted_games(&user_id, tc)
+                            .await?;
+                    }
+                    BulkAdjudication::ResetAdjudicated => {
+                        tournament.reset_adjudicated_games(&user_id, tc).await?;
+                    }
+                }
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await?;
+
+        Ok(vec![InternalServerMessage {
+            destination: MessageDestination::Global,
+            message: ServerMessage::Tournament(TournamentUpdate::Adjudicated(
+                self.tournament_id.clone(),
+            )),
+        }])
+    }
+}

--- a/apis/src/websocket/server_handlers/tournaments/handler.rs
+++ b/apis/src/websocket/server_handlers/tournaments/handler.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use super::{
     abandon::AbandonHandler,
     adjudicate_result::AdjudicateResultHandler,
+    bulk_adjudicate::{BulkAdjudicateHandler, BulkAdjudication},
     create::CreateHandler,
     delete::DeleteHandler,
     finish::FinishHandler,
@@ -116,6 +117,28 @@ impl TournamentHandler {
                     .await?
                     .handle()
                     .await?
+            }
+            TournamentAction::DoubleForfeitUnstartedGames(tournament_id) => {
+                BulkAdjudicateHandler::new(
+                    tournament_id,
+                    self.user_id,
+                    BulkAdjudication::DoubleForfeitUnstarted,
+                    &self.pool,
+                )
+                .await?
+                .handle()
+                .await?
+            }
+            TournamentAction::ResetAdjudicatedGames(tournament_id) => {
+                BulkAdjudicateHandler::new(
+                    tournament_id,
+                    self.user_id,
+                    BulkAdjudication::ResetAdjudicated,
+                    &self.pool,
+                )
+                .await?
+                .handle()
+                .await?
             }
             TournamentAction::Abandon(tournament_id) => {
                 AbandonHandler::new(

--- a/apis/src/websocket/server_handlers/tournaments/mod.rs
+++ b/apis/src/websocket/server_handlers/tournaments/mod.rs
@@ -1,5 +1,6 @@
 pub mod abandon;
 pub mod adjudicate_result;
+pub mod bulk_adjudicate;
 pub mod create;
 pub mod delete;
 pub mod finish;

--- a/db/src/models/game.rs
+++ b/db/src/models/game.rs
@@ -1151,42 +1151,80 @@ impl Game {
         new_result: &TournamentGameResult,
         conn: &mut DbConn<'_>,
     ) -> Result<Self, DbError> {
-        match Conclusion::from_str(&self.conclusion) {
-            Ok(Conclusion::Committee) | Ok(Conclusion::Unknown) | Ok(Conclusion::Forfeit) => {}
-            _ => {
-                return Err(DbError::InvalidAction {
-                    info: String::from("You cannot adjudicate a played game"),
-                });
-            }
+        if !(matches!(
+            Conclusion::from_str(&self.conclusion),
+            Ok(Conclusion::Committee) | Ok(Conclusion::Unknown) | Ok(Conclusion::Forfeit)
+        ) && self.turn == 0
+            && self.history.is_empty()
+            && self.game_start == GameStart::Ready.to_string()
+            && matches!(
+                GameStatus::from_str(&self.game_status),
+                Ok(GameStatus::NotStarted) | Ok(GameStatus::Adjudicated)
+            ))
+        {
+            return Err(DbError::InvalidAction {
+                info: String::from("You cannot adjudicate a game that has already started"),
+            });
         }
-        if let Some(tid) = self.tournament_id {
-            let tournament = Tournament::find(tid, conn).await?;
-            tournament
-                .ensure_user_is_organizer_or_admin(user_id, conn)
-                .await?;
-            let con = match new_result {
-                TournamentGameResult::DoubeForfeit => Conclusion::Forfeit,
-                TournamentGameResult::Unknown => Conclusion::Unknown,
-                _ => Conclusion::Committee,
-            };
-            let fin = new_result != &TournamentGameResult::Unknown;
-            let game = diesel::update(games::table.find(self.id))
-                .set((
-                    finished.eq(fin),
-                    conclusion.eq(con.to_string()),
-                    game_status.eq(GameStatus::Adjudicated.to_string()),
-                    tournament_game_result.eq(new_result.to_string()),
-                    updated_at.eq(Utc::now()),
-                    last_interaction.eq(Utc::now()),
-                ))
-                .get_result(conn)
-                .await?;
-            Ok(game)
-        } else {
-            Err(DbError::InvalidAction {
+
+        let tid = self.tournament_id.ok_or_else(|| DbError::InvalidAction {
+            info: String::from("Not a tournament game"),
+        })?;
+        let tournament = Tournament::find(tid, conn).await?;
+        tournament
+            .ensure_user_is_organizer_or_admin(user_id, conn)
+            .await?;
+
+        self.update_tournament_result(new_result, conn).await
+    }
+
+    pub(crate) async fn assign_tournament_result(
+        &self,
+        new_result: &TournamentGameResult,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Self, DbError> {
+        if self.tournament_id.is_none() {
+            return Err(DbError::InvalidAction {
                 info: String::from("Not a tournament game"),
-            })
+            });
         }
+        self.update_tournament_result(new_result, conn).await
+    }
+
+    async fn update_tournament_result(
+        &self,
+        new_result: &TournamentGameResult,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Self, DbError> {
+        let (con, status, fin, new_last_interaction) = match new_result {
+            TournamentGameResult::DoubeForfeit => (
+                Conclusion::Forfeit,
+                GameStatus::Adjudicated,
+                true,
+                Some(Utc::now()),
+            ),
+            TournamentGameResult::Unknown => {
+                (Conclusion::Unknown, GameStatus::NotStarted, false, None)
+            }
+            _ => (
+                Conclusion::Committee,
+                GameStatus::Adjudicated,
+                true,
+                Some(Utc::now()),
+            ),
+        };
+        let game = diesel::update(games::table.find(self.id))
+            .set((
+                finished.eq(fin),
+                conclusion.eq(con.to_string()),
+                game_status.eq(status.to_string()),
+                tournament_game_result.eq(new_result.to_string()),
+                updated_at.eq(Utc::now()),
+                last_interaction.eq(new_last_interaction),
+            ))
+            .get_result(conn)
+            .await?;
+        Ok(game)
     }
 
     pub async fn start(&self, conn: &mut DbConn<'_>) -> Result<Self, DbError> {

--- a/db/src/models/schedule.rs
+++ b/db/src/models/schedule.rs
@@ -196,6 +196,20 @@ impl Schedule {
         )
     }
 
+    pub async fn delete_for_games(
+        game_ids: &[Uuid],
+        conn: &mut DbConn<'_>,
+    ) -> Result<usize, DbError> {
+        if game_ids.is_empty() {
+            return Ok(0);
+        }
+        Ok(
+            diesel::delete(schedules::table.filter(schedules::game_id.eq_any(game_ids)))
+                .execute(conn)
+                .await?,
+        )
+    }
+
     pub async fn get_upcoming_agreed_games(
         conn: &mut DbConn<'_>,
     ) -> Result<Vec<(Uuid, DateTime<Utc>)>, DbError> {

--- a/db/src/models/tournament.rs
+++ b/db/src/models/tournament.rs
@@ -1,4 +1,4 @@
-use super::{Game, NewGame, TournamentInvitation};
+use super::{Game, NewGame, Schedule, TournamentInvitation};
 use crate::{
     db_error::DbError,
     models::{
@@ -26,12 +26,13 @@ use crate::{
 use chrono::{prelude::*, TimeDelta};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
-use hive_lib::Color;
+use hive_lib::{Color, GameStatus};
 use itertools::Itertools;
 use nanoid::nanoid;
 use rand::{rng, seq::SliceRandom};
 use serde::{Deserialize, Serialize};
 use shared_types::{
+    Conclusion,
     Standings,
     Tiebreaker,
     TimeMode,
@@ -320,6 +321,91 @@ impl Tournament {
             .get_result(conn)
             .await?;
         Ok(tournament)
+    }
+
+    pub async fn double_forfeit_unstarted_games(
+        &self,
+        user_id: &Uuid,
+        conn: &mut DbConn<'_>,
+    ) -> Result<usize, DbError> {
+        self.ensure_inprogress()?;
+        self.ensure_user_is_organizer_or_admin(user_id, conn)
+            .await?;
+
+        let unstarted_game_ids = self
+            .game_ids_with_status(GameStatus::NotStarted, conn)
+            .await?;
+
+        if unstarted_game_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let updated_games =
+            diesel::update(games::table.filter(games::id.eq_any(&unstarted_game_ids)))
+                .set((
+                    games::finished.eq(true),
+                    games::conclusion.eq(Conclusion::Forfeit.to_string()),
+                    games::game_status.eq(GameStatus::Adjudicated.to_string()),
+                    games::tournament_game_result
+                        .eq(TournamentGameResult::DoubeForfeit.to_string()),
+                    games::updated_at.eq(Utc::now()),
+                    games::last_interaction.eq(Utc::now()),
+                ))
+                .execute(conn)
+                .await?;
+
+        Schedule::delete_for_games(&unstarted_game_ids, conn).await?;
+
+        Ok(updated_games)
+    }
+
+    pub async fn reset_adjudicated_games(
+        &self,
+        user_id: &Uuid,
+        conn: &mut DbConn<'_>,
+    ) -> Result<usize, DbError> {
+        self.ensure_inprogress()?;
+        self.ensure_user_is_organizer_or_admin(user_id, conn)
+            .await?;
+
+        let unstarted_game_ids = self
+            .game_ids_with_status(GameStatus::Adjudicated, conn)
+            .await?;
+
+        if unstarted_game_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let updated_games =
+            diesel::update(games::table.filter(games::id.eq_any(&unstarted_game_ids)))
+                .set((
+                    games::finished.eq(false),
+                    games::conclusion.eq(Conclusion::Unknown.to_string()),
+                    games::game_status.eq(GameStatus::NotStarted.to_string()),
+                    games::tournament_game_result.eq(TournamentGameResult::Unknown.to_string()),
+                    games::updated_at.eq(Utc::now()),
+                    games::last_interaction.eq::<Option<DateTime<Utc>>>(None),
+                    games::turn.eq(0),
+                ))
+                .execute(conn)
+                .await?;
+
+        Schedule::delete_for_games(&unstarted_game_ids, conn).await?;
+
+        Ok(updated_games)
+    }
+
+    async fn game_ids_with_status(
+        &self,
+        status: GameStatus,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Vec<Uuid>, DbError> {
+        Ok(games::table
+            .filter(tournament_id_column.eq(self.id))
+            .filter(games::game_status.eq(status.to_string()))
+            .select(games::id)
+            .get_results(conn)
+            .await?)
     }
 
     pub async fn retract_invitation(
@@ -670,7 +756,6 @@ impl Tournament {
     }
 
     async fn swiss_create_first_round(&self, conn: &mut DbConn<'_>) -> Result<Vec<Game>, DbError> {
-        let organizer = &self.organizers(conn).await?[0].id;
         let mut players = self.players(conn).await?;
         let mut games = Vec::new();
 
@@ -706,12 +791,8 @@ impl Tournament {
                 } else {
                     None
                 } {
-                    game.adjudicate_tournament_result(
-                        organizer,
-                        &TournamentGameResult::Winner(winner),
-                        conn,
-                    )
-                    .await?;
+                    game.assign_tournament_result(&TournamentGameResult::Winner(winner), conn)
+                        .await?;
                 }
 
                 games.push(game);
@@ -825,9 +906,22 @@ impl Tournament {
 
     pub async fn swiss_create_next_round(
         &self,
-        user_id: &Uuid,
+        organizer: &Uuid,
         conn: &mut DbConn<'_>,
     ) -> Result<Vec<Game>, DbError> {
+        self.ensure_inprogress()?;
+        self.ensure_user_is_organizer_or_admin(organizer, conn)
+            .await?;
+        self.ensure_games_finished(conn).await?;
+
+        if TournamentMode::from_str(&self.mode).expect("Only valid modes should make it to the DB")
+            != TournamentMode::DoubleSwiss
+        {
+            return Err(DbError::InvalidAction {
+                info: String::from("Only Swiss tournaments can progress to the next round"),
+            });
+        }
+
         let played_games = self.games(conn).await?;
         let mut games = Vec::new();
         let mut standings = Standings::new();
@@ -885,12 +979,8 @@ impl Tournament {
                 } else {
                     None
                 } {
-                    game.adjudicate_tournament_result(
-                        user_id,
-                        &TournamentGameResult::Winner(winner),
-                        conn,
-                    )
-                    .await?;
+                    game.assign_tournament_result(&TournamentGameResult::Winner(winner), conn)
+                        .await?;
                 }
 
                 games.push(game);

--- a/engine/src/game_control.rs
+++ b/engine/src/game_control.rs
@@ -107,7 +107,7 @@ mod tests {
         ]
         .iter()
         {
-            assert_eq!(Ok(gc.clone()), GameControl::from_str(&format!("{gc}")));
+            assert_eq!(Ok(gc), GameControl::from_str(&format!("{gc}")));
         }
     }
 }


### PR DESCRIPTION
Allows organizers to adjudicate all unstated games to double forfeit.
Allows to undo all adjudications and make the games playable again.
Fixes bug where undoing an adjudication got the game into an unplayable state.

EDIT: ~~Draft pr as the frontend part needs work still and I want to do it after #663 is merged~~....Changed my mind about this frontend will be reworked in a separate pr.