### PR TITLE
refactor ControlButtons and fix styling

### DIFF
--- a/apis/src/components/atoms/gc_button.rs
+++ b/apis/src/components/atoms/gc_button.rs
@@ -3,20 +3,19 @@ use hive_lib::GameControl;
 use icondata_core;
 use leptos::prelude::*;
 use leptos_icons::*;
-use leptos_use::{use_interval_with_options, UseIntervalOptions};
-use std::sync::Arc;
+use leptos_use::{use_timeout_fn, UseTimeoutFnReturn};
 use uuid::Uuid;
 
 #[component]
 pub fn AcceptDenyGc(
-    game_control: StoredValue<GameControl>,
+    game_control: GameControl,
     user_id: Uuid,
-    #[prop(optional, into)] hidden: Signal<String>,
+    #[prop(optional, into)] hidden: Signal<bool>,
 ) -> impl IntoView {
     let game_state = expect_context::<GameStateSignal>();
-    let (icon, title) = get_icon_and_title(game_control.get_value());
+    let (icon, title) = get_icon_and_title(game_control);
 
-    let button_style = move || match game_control.get_value() {
+    let button_style = move || match game_control {
         GameControl::DrawReject(_) | GameControl::TakebackReject(_) => {
             "bg-red-700 hover:bg-ladybug-red absolute"
         }
@@ -24,70 +23,61 @@ pub fn AcceptDenyGc(
     };
 
     let on_click = move |_| {
-        game_state.send_game_control(game_control.get_value(), user_id);
+        game_state.send_game_control(game_control, user_id);
     };
     view! {
         <button
             title=title
             on:click=on_click
             class=move || {
+                let hidden = if hidden() { "hidden" } else { "" };
                 format!(
                     "aspect-square rounded-sm transform transition-transform duration-300 active:scale-95 [&>svg]:size-6 lg:[&>svg]:size-8 {} {}",
                     button_style(),
-                    hidden(),
+                    hidden,
                 )
             }
         >
 
-            <Icon icon=icon />
+            <Icon icon />
         </button>
     }
 }
 
 #[component]
 pub fn ConfirmButton(
-    game_control: StoredValue<GameControl>,
+    game_control: GameControl,
     user_id: Uuid,
-    #[prop(optional, into)] hidden: Signal<String>,
+    #[prop(optional, into)] hidden: Signal<bool>,
 ) -> impl IntoView {
-    let game_state = StoredValue::new(expect_context::<GameStateSignal>());
-    let (icon, title) = get_icon_and_title(game_control.get_value());
-    let color = game_control.with_value(|g| g.color());
+    let game_state = expect_context::<GameStateSignal>();
+    let pending_slice = create_read_slice(game_state.signal, |gs| gs.game_control_pending.clone());
+    let turn = create_read_slice(game_state.signal, |gs| gs.state.turn as i32);
+    let (icon, title) = get_icon_and_title(game_control);
+    let color = game_control.color();
     let is_clicked = RwSignal::new(false);
-    let interval = StoredValue::new(Arc::new(use_interval_with_options(
-        5000,
-        UseIntervalOptions::default().immediate(false),
-    )));
-
-    let onclick_confirm = move |_| {
-        let interval = interval.get_value();
-        if is_clicked() {
-            game_state
-                .read_value()
-                .send_game_control(game_control.get_value(), user_id);
+    let UseTimeoutFnReturn { start, stop, .. } = use_timeout_fn(
+        move |_: ()| {
             is_clicked.update(|v| *v = false);
-            (interval.reset)();
-            (interval.pause)();
+        },
+        5000.0,
+    );
+    let stop = StoredValue::new(stop);
+    let onclick_confirm = move |_| {
+        if is_clicked() {
+            (stop.get_value())();
+            game_state.send_game_control(game_control, user_id);
+            is_clicked.update(|v| *v = false);
         } else {
-            is_clicked.update(|v| *v = true);
-            (interval.resume)();
+            is_clicked.set(true);
+            start(());
         }
     };
 
-    Effect::new_isomorphic(move |_| {
-        let interval = interval.get_value();
-        if (interval.counter)() >= 1 {
-            is_clicked.update(|v| *v = false);
-            (interval.reset)();
-            (interval.pause)();
-        }
-    });
-
-    let pending_slice = create_read_slice(game_state.with_value(|gs| gs.signal), |gs| {
-        gs.game_control_pending.clone()
-    });
-
-    let cancel = move |_| is_clicked.update(|v| *v = false);
+    let cancel = move |_| {
+        (stop.get_value())();
+        is_clicked.set(false);
+    };
     let pending = move |game_control: GameControl| match pending_slice() {
         Some(GameControl::DrawOffer(gc_color)) => {
             if color == gc_color && matches!(game_control, GameControl::DrawOffer(_)) {
@@ -104,12 +94,8 @@ pub fn ConfirmButton(
         _ => false,
     };
 
-    let turn = create_read_slice(game_state.with_value(|gs| gs.signal), |gs| {
-        gs.state.turn as i32
-    });
-
     let disabled = move || {
-        let game_control = game_control.get_value();
+        let game_control = game_control;
         if game_control.allowed_on_turn(turn()) {
             !matches!(game_control, GameControl::Resign(_))
                 && (pending(GameControl::DrawOffer(color))
@@ -119,43 +105,23 @@ pub fn ConfirmButton(
         }
     };
 
-    let conditional_button_style = move || {
-        if is_clicked() {
+    let class = move || {
+        let base = String::from("aspect-square rounded-sm relative transform transition-transform duration-300 active:scale-95 [&>svg]:size-6 lg:[&>svg]:size-8 ");
+        base + if is_clicked() {
             "bg-grasshopper-green hover:bg-green-500"
-        } else if pending(game_control.get_value()) {
-            "bg-pullbug-teal"
+        } else if pending(game_control) {
+            "bg-pillbug-teal text-slate-500"
         } else if disabled() {
-            ""
+            "text-slate-500"
         } else {
             "hover:bg-grasshopper-green"
         }
     };
 
-    let conditional_icon_style = move || {
-        if disabled() {
-            "fill-slate-500"
-        } else {
-            ""
-        }
-    };
-
     view! {
-        <div class=move || format!("relative {}", hidden())>
-            <button
-                title=title
-                on:click=onclick_confirm
-                prop:disabled=disabled
-
-                class=move || {
-                    format!(
-                        "aspect-square rounded-sm relative transform transition-transform duration-300 active:scale-95 [&>svg]:size-6 lg:[&>svg]:size-8 {}",
-                        conditional_button_style(),
-                    )
-                }
-            >
-
-                <Icon icon=icon attr:class=conditional_icon_style />
-
+        <div class=move || { if hidden() { "relative hidden" } else { "relative" } }>
+            <button title=title on:click=onclick_confirm disabled=disabled class=class>
+                <Icon icon />
             </button>
             <Show when=is_clicked>
                 <button

--- a/apis/src/components/molecules/control_buttons.rs
+++ b/apis/src/components/molecules/control_buttons.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 use hive_lib::{ColorChoice, GameControl};
-use leptos::prelude::*;
+use leptos::{either::EitherOf3, prelude::*};
 use leptos_router::hooks::use_navigate;
 use shared_types::{ChallengeDetails, ChallengeVisibility};
 
@@ -25,7 +25,7 @@ pub fn ControlButtons() -> impl IntoView {
                 .expect("Control buttons show only for logged in players")
         })
     };
-
+    let is_finished = game_state.is_finished();
     let color = Signal::derive(move || {
         game_state
             .user_color_as_signal(Some(user_id()).into())
@@ -55,11 +55,11 @@ pub fn ControlButtons() -> impl IntoView {
             Default::default(),
         );
     };
-    let pending_draw = move || match pending() {
+    let pending_draw = Signal::derive(move || match pending() {
         Some(GameControl::DrawOffer(gc_color)) => gc_color.opposite_color() == color(),
 
         _ => false,
-    };
+    });
 
     let pending_takeback = move || match pending() {
         Some(GameControl::TakebackRequest(gc_color)) => gc_color.opposite_color() == color(),
@@ -181,113 +181,10 @@ pub fn ControlButtons() -> impl IntoView {
             });
         }
     };
-
-    view! {
-        <div class="flex justify-around items-center w-full grow shrink">
-            <Show
-                when=game_state.is_finished()
-                fallback=move || {
-                    view! {
-                        <div class="flex flex-col w-full">
-                            <div class="flex justify-around items-center pt-1 grow shrink">
-                                <Show when=not_tournament>
-                                    <div class="relative">
-                                        <ConfirmButton
-                                            game_control=StoredValue::new(GameControl::Abort(color()))
-                                            user_id=user_id()
-                                            hidden=memo_for_hidden_class(move || {
-                                                game_state.signal.with(|gs| gs.state.turn > 1)
-                                            })
-                                        />
-                                        <Show when=takeback_allowed>
-                                            <ConfirmButton
-                                                game_control=StoredValue::new(
-                                                    GameControl::TakebackRequest(color()),
-                                                )
-
-                                                user_id=user_id()
-                                                hidden=memo_for_hidden_class(move || {
-                                                    pending_takeback()
-                                                        || game_state.signal.with(|gs| gs.state.turn < 2)
-                                                })
-                                            />
-
-                                            <AcceptDenyGc
-                                                game_control=StoredValue::new(
-                                                    GameControl::TakebackAccept(color()),
-                                                )
-
-                                                user_id=user_id()
-                                                hidden=memo_for_hidden_class(move || !pending_takeback())
-                                            />
-                                            <AcceptDenyGc
-                                                game_control=StoredValue::new(
-                                                    GameControl::TakebackReject(color()),
-                                                )
-
-                                                user_id=user_id()
-                                                hidden=memo_for_hidden_class(move || !pending_takeback())
-                                            />
-                                        </Show>
-                                    </div>
-                                </Show>
-                                <div class="relative">
-                                    <ConfirmButton
-                                        game_control=StoredValue::new(
-                                            GameControl::DrawOffer(color()),
-                                        )
-                                        user_id=user_id()
-                                        hidden=memo_for_hidden_class(pending_draw)
-                                    />
-
-                                    <AcceptDenyGc
-                                        game_control=StoredValue::new(
-                                            GameControl::DrawAccept(color()),
-                                        )
-                                        user_id=user_id()
-                                        hidden=memo_for_hidden_class(move || !pending_draw())
-                                    />
-                                    <AcceptDenyGc
-                                        game_control=StoredValue::new(
-                                            GameControl::DrawReject(color()),
-                                        )
-                                        user_id=user_id()
-                                        hidden=memo_for_hidden_class(move || !pending_draw())
-                                    />
-                                </div>
-                                <ConfirmButton
-                                    game_control=StoredValue::new(GameControl::Resign(color()))
-                                    user_id=user_id()
-                                />
-                            </div>
-
-                            <div class="flex justify-center w-full h-5">
-                                <Show when=pending_takeback>
-                                    <span class="font-bold">"Opponent wants a takeback"</span>
-                                </Show>
-                                <Show when=pending_draw>
-                                    <span class="font-bold">"Opponent offers a draw"</span>
-                                </Show>
-                            </div>
-                        </div>
-                    }
-                }
-            >
-
-                <Show
-                    when=not_tournament
-                    fallback=move || {
-                        view! {
-                            <button
-                                class="flex-shrink-0 py-1 px-2 m-1 h-7 font-bold text-white rounded transition-transform duration-300 active:scale-95 grow bg-button-dawn dark:bg-button-twilight dark:hover:bg-pillbug-teal hover:bg-pillbug-teal"
-                                on:click=navigate_to_tournament
-                            >
-                                View tournament
-                            </button>
-                        }
-                    }
-                >
-
+    move || {
+        if is_finished() {
+            if not_tournament() {
+                EitherOf3::A(view! {
                     <button
                         class=move || {
                             format!(
@@ -307,18 +204,89 @@ pub fn ControlButtons() -> impl IntoView {
                     >
                         New Game
                     </button>
-                </Show>
-            </Show>
-        </div>
-    }
-}
-
-fn memo_for_hidden_class(condition: impl Fn() -> bool + Send + Sync + 'static) -> Memo<String> {
-    Memo::new(move |_| {
-        if condition() {
-            String::from("hidden")
+                })
+            } else {
+                EitherOf3::B(view! {
+                    <button
+                        class="flex-shrink-0 py-1 px-2 m-1 h-7 font-bold text-white rounded transition-transform duration-300 active:scale-95 grow bg-button-dawn dark:bg-button-twilight dark:hover:bg-pillbug-teal hover:bg-pillbug-teal"
+                        on:click=navigate_to_tournament
+                    >
+                        View tournament
+                    </button>
+                })
+            }
         } else {
-            String::new()
+            EitherOf3::C(view! {
+                <div class="flex flex-col w-full">
+                    <div class="flex justify-around items-center pt-1 grow shrink">
+                        <Show when=not_tournament>
+                            <div class="relative">
+                                <ConfirmButton
+                                    game_control=GameControl::Abort(color())
+                                    user_id=user_id()
+
+                                    hidden=Signal::derive(move || {
+                                        game_state.signal.with(|gs| gs.state.turn > 1)
+                                    })
+                                />
+                                <Show when=takeback_allowed>
+                                    <ConfirmButton
+                                        game_control=GameControl::TakebackRequest(color())
+                                        user_id=user_id()
+                                        hidden=Signal::derive(move || {
+                                            pending_takeback()
+                                                || game_state.signal.with(|gs| gs.state.turn < 2)
+                                        })
+                                    />
+
+                                    <AcceptDenyGc
+                                        game_control=GameControl::TakebackAccept(color())
+
+                                        user_id=user_id()
+                                        hidden=Signal::derive(move || !pending_takeback())
+                                    />
+                                    <AcceptDenyGc
+                                        game_control=GameControl::TakebackReject(color())
+                                        user_id=user_id()
+                                        hidden=Signal::derive(move || !pending_takeback())
+                                    />
+                                </Show>
+                            </div>
+                        </Show>
+                        <div class="relative">
+                            <ConfirmButton
+                                game_control=GameControl::DrawOffer(color())
+                                user_id=user_id()
+                                hidden=pending_draw
+                            />
+
+                            <AcceptDenyGc
+                                game_control=GameControl::DrawAccept(color())
+                                user_id=user_id()
+                                hidden=Signal::derive(move || !pending_draw())
+                            />
+                            <AcceptDenyGc
+                                game_control=GameControl::DrawReject(color())
+                                user_id=user_id()
+                                hidden=Signal::derive(move || !pending_draw())
+                            />
+                        </div>
+                        <ConfirmButton
+                            game_control=GameControl::Resign(color())
+                            user_id=user_id()
+                        />
+                    </div>
+
+                    <div class="flex justify-center w-full h-5">
+                        <Show when=pending_takeback>
+                            <span class="font-bold">"Opponent wants a takeback"</span>
+                        </Show>
+                        <Show when=pending_draw>
+                            <span class="font-bold">"Opponent offers a draw"</span>
+                        </Show>
+                    </div>
+                </div>
+            })
         }
-    })
+    }
 }

--- a/engine/src/game_control.rs
+++ b/engine/src/game_control.rs
@@ -2,7 +2,7 @@ use crate::{color::Color, game_error::GameError};
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Copy)]
 pub enum GameControl {
     Abort(Color),
     DrawAccept(Color),


### PR DESCRIPTION
- Derive copy for GameControl (a small type) to avoid passing a StoredValue around
- Delete memo_for_hidden_class, pass a normal Signal<bool> and handle the logic in each function (which is not much)
- Rely on use_timeout_fn to handle the timeout logic instead of the interval+isomorphic effect
- Dont use nested shows/fallbacks in gc_control, do an EitherOf3 for readability (and to play well with Stores in the future)
-  Fix styling, now backround teal color shows on action pending