### PR TITLE
Analysis improve

### DIFF
--- a/apis/src/components/atoms/active.rs
+++ b/apis/src/components/atoms/active.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::{ActiveState, SvgPos},
-    providers::game_state::GameStateSignal,
+    providers::game_state::GameStateStore,
 };
 use hive_lib::Position;
 use leptos::{either::Either, prelude::*, text_prop::TextProp};
@@ -13,7 +13,7 @@ pub fn Active(
     active_state: ActiveState,
     straight: bool,
 ) -> impl IntoView {
-    let mut game_signal = expect_context::<GameStateSignal>();
+    let game_signal = expect_context::<GameStateStore>();
     let center = move || SvgPos::center_for_level(position, level, straight);
     let transform = TextProp::from(move || format!("translate({},{})", center().0, center().1));
     match active_state {

--- a/apis/src/components/atoms/download_pgn.rs
+++ b/apis/src/components/atoms/download_pgn.rs
@@ -4,22 +4,25 @@ use leptos_icons::*;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{js_sys::Array, Blob, Url};
 
-use crate::{providers::game_state::GameStateSignal, responses::GameResponse};
+use crate::{
+    providers::game_state::{GameStateStore, GameStateStoreFields},
+    responses::GameResponse,
+};
 
 #[component]
 pub fn DownloadPgn(
     #[prop(optional, into)] game: Option<StoredValue<GameResponse>>,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let maybe_game = move || {
         if let Some(game) = game {
             Some(game)
         } else {
-            game_state.signal.with(|gs| {
-                gs.game_response
-                    .as_ref()
-                    .map(|v| StoredValue::new(v.clone()))
-            })
+            game_state
+                .game_response()
+                .get()
+                .as_ref()
+                .map(|v| StoredValue::new(v.clone()))
         }
     };
     let download = move |_| {

--- a/apis/src/components/atoms/gc_button.rs
+++ b/apis/src/components/atoms/gc_button.rs
@@ -1,4 +1,4 @@
-use crate::providers::game_state::GameStateSignal;
+use crate::providers::game_state::{GameStateStore, GameStateStoreFields};
 use hive_lib::GameControl;
 use icondata_core;
 use leptos::prelude::*;
@@ -12,7 +12,7 @@ pub fn AcceptDenyGc(
     user_id: Uuid,
     #[prop(optional, into)] hidden: Signal<bool>,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let (icon, title) = get_icon_and_title(game_control);
 
     let button_style = move || match game_control {
@@ -50,9 +50,9 @@ pub fn ConfirmButton(
     user_id: Uuid,
     #[prop(optional, into)] hidden: Signal<bool>,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
-    let pending_slice = create_read_slice(game_state.signal, |gs| gs.game_control_pending.clone());
-    let turn = create_read_slice(game_state.signal, |gs| gs.state.turn as i32);
+    let game_state = expect_context::<GameStateStore>();
+    let pending_slice = Signal::derive(move || game_state.game_control_pending().get());
+    let turn = Signal::derive(move || game_state.state().get().turn as i32);
     let (icon, title) = get_icon_and_title(game_control);
     let color = game_control.color();
     let is_clicked = RwSignal::new(false);
@@ -95,7 +95,6 @@ pub fn ConfirmButton(
     };
 
     let disabled = move || {
-        let game_control = game_control;
         if game_control.allowed_on_turn(turn()) {
             !matches!(game_control, GameControl::Resign(_))
                 && (pending(GameControl::DrawOffer(color))

--- a/apis/src/components/atoms/hex.rs
+++ b/apis/src/components/atoms/hex.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{Direction, Hex, HexType, PieceType},
     components::atoms::{active::Active, last_move::LastMove, piece::Piece, target::Target},
-    providers::{config::TileOptions, game_state::GameStateSignal},
+    providers::{config::TileOptions, game_state::GameStateStore},
 };
 use hive_lib::Position;
 use leptos::{either::EitherOf4, prelude::*};
@@ -12,7 +12,7 @@ pub fn Hex(
     tile_opts: TileOptions,
     target_stack: RwSignal<Option<Position>>,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let straight = tile_opts.clone().is_three_d();
     let level_multiplier = move || match target_stack() {
         Some(pos) => {
@@ -30,9 +30,7 @@ pub fn Hex(
 
     match hex.kind {
         HexType::Active(active_state) => {
-            let level = if game_state
-                .signal
-                .with_untracked(|gs| gs.move_info.target_position.is_none())
+            let level = if game_state.with_untracked(|gs| gs.move_info.target_position.is_none())
                 || hex.level == 0
             {
                 expanded_level.get_untracked()

--- a/apis/src/components/atoms/history_button.rs
+++ b/apis/src/components/atoms/history_button.rs
@@ -1,7 +1,7 @@
 use crate::{
     components::organisms::side_board::move_query_signal,
     providers::{
-        game_state::GameStateSignal,
+        game_state::GameStateStore,
         timer::{Timer, TimerSignal},
     },
 };
@@ -25,7 +25,7 @@ pub fn HistoryButton(
     #[prop(optional)] post_action: Option<Callback<()>>,
     #[prop(optional)] node_ref: Option<NodeRef<html::Button>>,
 ) -> impl IntoView {
-    let game_state_signal = expect_context::<GameStateSignal>();
+    let game_state_signal = expect_context::<GameStateStore>();
     let timer = expect_context::<TimerSignal>();
     let (_move, set_move) = move_query_signal();
     let is_last_turn = game_state_signal.is_last_turn_as_signal();
@@ -51,7 +51,7 @@ pub fn HistoryButton(
         if let Some(post_action) = post_action {
             post_action.run(())
         }
-        let turn = game_state_signal.signal.with_untracked(|gs| match action {
+        let turn = game_state_signal.with_untracked(|gs| match action {
             HistoryNavigation::Last => Some(gs.state.turn),
             HistoryNavigation::MobileLast => None,
             _ => gs.history_turn.map(|v| v + 1),
@@ -73,24 +73,15 @@ pub fn HistoryButton(
     }
 }
 
-fn send_action(
-    action: &HistoryNavigation,
-    mut game_state_signal: GameStateSignal,
-    timer: TimerSignal,
-) {
+fn send_action(action: &HistoryNavigation, game_state_signal: GameStateStore, timer: TimerSignal) {
     match action {
         HistoryNavigation::First => game_state_signal.first_history_turn(),
         HistoryNavigation::Last => game_state_signal.view_history(),
         HistoryNavigation::Next => game_state_signal.next_history_turn(),
         HistoryNavigation::Previous => game_state_signal.previous_history_turn(),
         HistoryNavigation::MobileLast => {
-            if game_state_signal
-                .signal
-                .with_untracked(|gs| gs.state.turn > 0)
-            {
-                game_state_signal
-                    .signal
-                    .update_untracked(|s| s.history_turn = Some(s.state.turn - 1));
+            if game_state_signal.with_untracked(|gs| gs.state.turn > 0) {
+                game_state_signal.update_untracked(|s| s.history_turn = Some(s.state.turn - 1));
             }
             game_state_signal.view_game()
         }
@@ -98,8 +89,8 @@ fn send_action(
     set_timer_from_response(game_state_signal, timer);
 }
 
-pub fn set_timer_from_response(game_state_signal: GameStateSignal, timer: TimerSignal) {
-    game_state_signal.signal.with(|gs| {
+pub fn set_timer_from_response(game_state_signal: GameStateStore, timer: TimerSignal) {
+    game_state_signal.with(|gs| {
         if !matches!(
             gs.state.game_status,
             GameStatus::Finished(_) | GameStatus::Adjudicated

--- a/apis/src/components/atoms/piece.rs
+++ b/apis/src/components/atoms/piece.rs
@@ -2,7 +2,7 @@ use crate::{
     common::{MoveConfirm, PieceType, SvgPos, TileDesign, TileDots, TileRotation},
     pages::play::CurrentConfirm,
     providers::{
-        analysis::AnalysisSignal,
+        analysis::AnalysisStore,
         config::TileOptions,
         game_state::{GameStateStore, GameStateStoreFields},
         ApiRequestsProvider,
@@ -195,7 +195,7 @@ pub fn PieceWithOnClick(
     #[prop(optional, into)] piece_type: PieceType,
     tile_opts: TileOptions,
 ) -> impl IntoView {
-    let analysis = use_context::<AnalysisSignal>();
+    let analysis = use_context::<AnalysisStore>();
     let game_state = expect_context::<GameStateStore>();
     let auth_context = expect_context::<AuthContext>();
     let api = expect_context::<ApiRequestsProvider>().0;

--- a/apis/src/components/atoms/piece.rs
+++ b/apis/src/components/atoms/piece.rs
@@ -4,7 +4,7 @@ use crate::{
     providers::{
         analysis::AnalysisSignal,
         config::TileOptions,
-        game_state::GameStateSignal,
+        game_state::{GameStateStore, GameStateStoreFields},
         ApiRequestsProvider,
         AuthContext,
         Config,
@@ -21,7 +21,7 @@ pub fn PieceWithoutOnClick(
     #[prop(into)] level: Signal<usize>,
     #[prop(into)] tile_opts: TileOptions,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let piece = piece.get_untracked();
     let tile_opts = StoredValue::new(tile_opts);
     let three_d = move || tile_opts.read_value().is_three_d();
@@ -82,9 +82,9 @@ pub fn PieceWithoutOnClick(
         },
     };
 
-    let active_piece = create_read_slice(game_state.signal, |gs| gs.move_info.active);
-    let last_move = create_read_slice(game_state.signal, |gs| gs.state.board.last_move);
-    let board_state = create_read_slice(game_state.signal, |gs| gs.state.board.clone());
+    let active_piece = Signal::derive(move || game_state.move_info().get().active);
+    let last_move = Signal::derive(move || game_state.state().get().board.last_move);
+    let board_state = Signal::derive(move || game_state.state().get().board.clone());
     let top_piece = move || board_state.with(|board| board.top_piece(position).unwrap_or(piece));
     let show_ds = move || {
         let top_piece = top_piece();
@@ -196,7 +196,7 @@ pub fn PieceWithOnClick(
     tile_opts: TileOptions,
 ) -> impl IntoView {
     let analysis = use_context::<AnalysisSignal>();
-    let mut game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let auth_context = expect_context::<AuthContext>();
     let api = expect_context::<ApiRequestsProvider>().0;
     let current_confirm = expect_context::<CurrentConfirm>().0;
@@ -205,7 +205,7 @@ pub fn PieceWithOnClick(
         evt.stop_propagation();
         let piece_value = piece.get_untracked();
         let in_analysis = analysis.is_some();
-        let current_turn_color = game_state.signal.with_untracked(|gs| gs.state.turn_color);
+        let current_turn_color = game_state.with_untracked(|gs| gs.state.turn_color);
 
         let is_selectable_piece = config.get_untracked().allow_preselect
             && match piece_type {
@@ -215,7 +215,7 @@ pub fn PieceWithOnClick(
                 }
                 _ => false,
             };
-        let is_current_player = game_state.signal.with_untracked(|gs| {
+        let is_current_player = game_state.with_untracked(|gs| {
             auth_context
                 .user
                 .with_untracked(|a| gs.uid_is_player(a.as_ref().map(|u| u.id)))
@@ -236,7 +236,7 @@ pub fn PieceWithOnClick(
                 _ => {}
             };
         } else if !in_analysis && is_current_player && is_selectable_piece {
-            game_state.signal.update(|v| {
+            game_state.update(|v| {
                 v.move_info.active = Some((piece_value, piece_type));
                 if piece_type == PieceType::Board {
                     v.move_info.current_position = Some(position);

--- a/apis/src/components/atoms/target.rs
+++ b/apis/src/components/atoms/target.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{MoveConfirm, SvgPos},
     pages::play::CurrentConfirm,
-    providers::{analysis::AnalysisSignal, game_state::GameStateSignal, ApiRequestsProvider},
+    providers::{analysis::AnalysisSignal, game_state::GameStateStore, ApiRequestsProvider},
 };
 use hive_lib::Position;
 use leptos::prelude::*;
@@ -16,7 +16,7 @@ pub fn Target(
     let current_confirm = expect_context::<CurrentConfirm>().0;
     let center = move || SvgPos::center_for_level(position, level(), straight);
     let transform = move || format!("translate({},{})", center().0, center().1);
-    let mut game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let analysis = use_context::<AnalysisSignal>();
     let api = expect_context::<ApiRequestsProvider>().0;
     // Select the target position and make a move if it's the correct mode

--- a/apis/src/components/atoms/target.rs
+++ b/apis/src/components/atoms/target.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{MoveConfirm, SvgPos},
     pages::play::CurrentConfirm,
-    providers::{analysis::AnalysisSignal, game_state::GameStateStore, ApiRequestsProvider},
+    providers::{analysis::AnalysisStore, game_state::GameStateStore, ApiRequestsProvider},
 };
 use hive_lib::Position;
 use leptos::prelude::*;
@@ -17,7 +17,7 @@ pub fn Target(
     let center = move || SvgPos::center_for_level(position, level(), straight);
     let transform = move || format!("translate({},{})", center().0, center().1);
     let game_state = expect_context::<GameStateStore>();
-    let analysis = use_context::<AnalysisSignal>();
+    let analysis = use_context::<AnalysisStore>();
     let api = expect_context::<ApiRequestsProvider>().0;
     // Select the target position and make a move if it's the correct mode
     let onclick = move |_| {

--- a/apis/src/components/layouts/base_layout.rs
+++ b/apis/src/components/layouts/base_layout.rs
@@ -5,7 +5,7 @@ use crate::{
         organisms::header::Header,
     },
     providers::{
-        game_state::GameStateSignal,
+        game_state::{GameState, GameStateStore, GameStateStoreFields},
         refocus::RefocusSignal,
         websocket::WebsocketContext,
         AuthContext,
@@ -26,6 +26,7 @@ use leptos_use::{
     use_window_focus,
     utils::Pausable,
 };
+use reactive_stores::Store;
 
 cfg_if! { if #[cfg(not(feature = "ssr"))] {
     use leptos_use::utils::IS_IOS;
@@ -52,13 +53,13 @@ pub struct OrientationSignal {
 
 #[component]
 pub fn BaseLayout(children: ChildrenFn) -> impl IntoView {
-    provide_context(GameStateSignal::new());
+    provide_context(GameStateStore(Store::new(GameState::new())));
     let config = expect_context::<Config>().0;
     let ping = expect_context::<PingContext>();
     let ws = expect_context::<WebsocketContext>();
     let ws_ready = ws.ready_state;
     let auth_context = expect_context::<AuthContext>();
-    let gamestate = expect_context::<GameStateSignal>();
+    let gamestate = expect_context::<GameStateStore>();
     let mut refocus = expect_context::<RefocusSignal>();
     let update_notifier = expect_context::<UpdateNotifier>();
     let orientation_vertical = use_media_query("(orientation: portrait), (max-width: 640px)");
@@ -93,11 +94,12 @@ pub fn BaseLayout(children: ChildrenFn) -> impl IntoView {
             .with_untracked(|a| a.as_ref().map(|user| user.id))
     });
     let user_color = gamestate.user_color_as_signal(user_id);
-    let has_gamecontrol = create_read_slice(gamestate.signal, move |gs| {
+    let pending_gc = gamestate.game_control_pending();
+    let has_gamecontrol = Signal::derive(move || {
         if let Some(color) = user_color() {
             let opp_color = color.opposite_color();
             matches!(
-                gs.game_control_pending,
+                pending_gc.get(),
                 Some(GameControl::TakebackRequest(color) | GameControl::DrawOffer(color)) if color == opp_color
             )
         } else {

--- a/apis/src/components/molecules/analysis_and_download.rs
+++ b/apis/src/components/molecules/analysis_and_download.rs
@@ -1,4 +1,7 @@
-use crate::{components::atoms::download_pgn::DownloadPgn, providers::game_state::GameStateSignal};
+use crate::{
+    components::atoms::download_pgn::DownloadPgn,
+    providers::game_state::{GameStateStore, GameStateStoreFields},
+};
 use leptos::prelude::*;
 use leptos_icons::*;
 use leptos_router::hooks::{use_params_map, use_query_map};
@@ -6,11 +9,11 @@ use shared_types::GameSpeed;
 
 #[component]
 pub fn AnalysisAndDownload() -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let params = use_params_map();
     let queries = use_query_map();
-    let correspondence = create_read_slice(game_state.signal, |gs| {
-        gs.game_response.as_ref().is_some_and(|gr| {
+    let correspondence = Signal::derive(move || {
+        game_state.game_response().get().as_ref().is_some_and(|gr| {
             gr.speed == GameSpeed::Correspondence || gr.speed == GameSpeed::Untimed
         })
     });

--- a/apis/src/components/molecules/board_pieces.rs
+++ b/apis/src/components/molecules/board_pieces.rs
@@ -1,7 +1,10 @@
 use crate::{
     common::{Direction, HexStack, PieceType},
     components::molecules::hex_stack::HexStack as HexStackView,
-    providers::{config::TileOptions, game_state::GameStateSignal},
+    providers::{
+        config::TileOptions,
+        game_state::{GameStateStore, GameStateStoreFields},
+    },
 };
 use hive_lib::Position;
 use leptos::prelude::*;
@@ -11,9 +14,9 @@ pub fn BoardPieces(
     tile_opts: TileOptions,
     target_stack: RwSignal<Option<Position>>,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
-    let move_info = create_read_slice(game_state.signal, |gs| gs.move_info.clone());
-    let state = create_read_slice(game_state.signal, |gs| gs.state.clone());
+    let game_state = expect_context::<GameStateStore>();
+    let move_info = Signal::derive(move || game_state.move_info().get());
+    let state = Signal::derive(move || game_state.state().get());
     // TODO get the BOARD_SIZE from board
     let board = move || {
         let move_info = move_info();

--- a/apis/src/components/molecules/board_pieces.rs
+++ b/apis/src/components/molecules/board_pieces.rs
@@ -15,12 +15,10 @@ pub fn BoardPieces(
     target_stack: RwSignal<Option<Position>>,
 ) -> impl IntoView {
     let game_state = expect_context::<GameStateStore>();
-    let move_info = Signal::derive(move || game_state.move_info().get());
-    let state = Signal::derive(move || game_state.state().get());
     // TODO get the BOARD_SIZE from board
     let board = move || {
-        let move_info = move_info();
-        state.with(|state| {
+        let move_info = game_state.move_info().get();
+        game_state.state().with(|state| {
             let mut board = Vec::new();
             let targets = move_info.target_positions;
             let last_move = state.board.last_move;

--- a/apis/src/components/molecules/chat_and_controls.rs
+++ b/apis/src/components/molecules/chat_and_controls.rs
@@ -4,7 +4,7 @@ use crate::{
         layouts::base_layout::OrientationSignal,
         organisms::dropdowns::chat::ChatDropdown,
     },
-    providers::game_state::GameStateSignal,
+    providers::game_state::GameStateStore,
 };
 use leptos::prelude::*;
 use leptos_router::hooks::use_location;
@@ -13,7 +13,7 @@ use shared_types::SimpleDestination;
 #[component]
 pub fn ChatAndControls() -> impl IntoView {
     let location = use_location();
-    let gamestate = expect_context::<GameStateSignal>();
+    let gamestate = expect_context::<GameStateStore>();
     let orientation_signal = expect_context::<OrientationSignal>();
     let is_finished = gamestate.is_finished();
     let in_mobile_game = move || {

--- a/apis/src/components/molecules/control_buttons.rs
+++ b/apis/src/components/molecules/control_buttons.rs
@@ -3,7 +3,7 @@ use crate::{
     components::atoms::gc_button::{AcceptDenyGc, ConfirmButton},
     providers::{
         challenges::ChallengeStateSignal,
-        game_state::GameStateSignal,
+        game_state::{GameStateStore, GameStateStoreFields},
         ApiRequestsProvider,
         AuthContext,
     },
@@ -15,7 +15,7 @@ use shared_types::{ChallengeDetails, ChallengeVisibility};
 
 #[component]
 pub fn ControlButtons() -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let auth_context = expect_context::<AuthContext>();
     let api = expect_context::<ApiRequestsProvider>().0;
     let user_id = move || {
@@ -32,25 +32,27 @@ pub fn ControlButtons() -> impl IntoView {
             .get()
             .expect("User_id is one of the players in this game")
     });
-    let pending = create_read_slice(game_state.signal, |gs| gs.game_control_pending.clone());
-    let not_tournament = create_read_slice(game_state.signal, |gs| {
-        gs.game_response
-            .as_ref()
+    let pending = Signal::derive(move || game_state.game_control_pending().get());
+    let not_tournament = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .is_some_and(|gr| gr.tournament.is_none())
     });
-    let takeback_allowed = create_read_slice(game_state.signal, |gs| gs.takeback_allowed());
+    let takeback_allowed = Signal::derive(move || game_state.takeback_allowed());
     //TODO: Check whether this button works as intended
     let navigate_to_tournament = move |_| {
         let navigate = use_navigate();
         navigate(
             &format!(
                 "/tournament/{}",
-                game_state
-                    .signal
-                    .with(|gs| gs.game_response.as_ref().map_or(String::new(), |gr| gr
-                        .tournament
-                        .as_ref()
-                        .map_or(String::new(), |t| t.tournament_id.to_string())))
+                game_state.with(|gs| {
+                    gs.game_response.as_ref().map_or(String::new(), |gr| {
+                        gr.tournament
+                            .as_ref()
+                            .map_or(String::new(), |t| t.tournament_id.to_string())
+                    })
+                })
             ),
             Default::default(),
         );
@@ -68,7 +70,7 @@ pub fn ControlButtons() -> impl IntoView {
     };
 
     let new_opponent = move |_| {
-        game_state.signal.with_untracked(|gs| {
+        game_state.with_untracked(|gs| {
             if let Some(game) = &gs.game_response {
                 let details = ChallengeDetails {
                     rated: game.rated,
@@ -93,7 +95,7 @@ pub fn ControlButtons() -> impl IntoView {
 
     let rematch_present = move || {
         let challenge_state_signal = expect_context::<ChallengeStateSignal>();
-        game_state.signal.with(|gs| {
+        game_state.with(|gs| {
             if let Some(game_response) = &gs.game_response {
                 challenge_state_signal.signal.with(|cs| {
                     cs.challenges
@@ -152,7 +154,7 @@ pub fn ControlButtons() -> impl IntoView {
             let api = api.get();
             api.challenge_accept(challenge.challenge_id);
         } else if let Some(user_id) = auth_context.user.with(|a| a.as_ref().map(|u| u.id)) {
-            game_state.signal.with_untracked(|gs| {
+            game_state.with_untracked(|gs| {
                 if let Some(game) = &gs.game_response {
                     // TODO: color and opponent
                     let (color_choice, opponent) = if user_id == game.black_player.uid {
@@ -226,7 +228,7 @@ pub fn ControlButtons() -> impl IntoView {
                                     user_id=user_id()
 
                                     hidden=Signal::derive(move || {
-                                        game_state.signal.with(|gs| gs.state.turn > 1)
+                                        game_state.with(|gs| gs.state.turn > 1)
                                     })
                                 />
                                 <Show when=takeback_allowed>
@@ -235,7 +237,7 @@ pub fn ControlButtons() -> impl IntoView {
                                         user_id=user_id()
                                         hidden=Signal::derive(move || {
                                             pending_takeback()
-                                                || game_state.signal.with(|gs| gs.state.turn < 2)
+                                                || game_state.with(|gs| gs.state.turn < 2)
                                         })
                                     />
 

--- a/apis/src/components/molecules/game_info.rs
+++ b/apis/src/components/molecules/game_info.rs
@@ -1,7 +1,7 @@
 use crate::{
     components::molecules::time_row::TimeRow,
     i18n::*,
-    providers::game_state::GameStateSignal,
+    providers::game_state::{GameStateStore, GameStateStoreFields},
 };
 use hive_lib::{Color, GameResult, GameStatus};
 use leptos::{either::Either, prelude::*};
@@ -10,9 +10,9 @@ use shared_types::{Conclusion, PrettyString, TimeInfo, TournamentGameResult, Tou
 #[component]
 pub fn GameInfo(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
     let i18n = use_i18n();
-    let game_state = expect_context::<GameStateSignal>();
-    let game_info = create_read_slice(game_state.signal, |gs| {
-        gs.game_response.as_ref().map(|gr| {
+    let game_state = expect_context::<GameStateStore>();
+    let game_info = Signal::derive(move || {
+        game_state.game_response().get().as_ref().map(|gr| {
             (
                 TimeInfo {
                     mode: gr.time_mode,
@@ -23,29 +23,39 @@ pub fn GameInfo(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoV
             )
         })
     });
-    let game_status = create_read_slice(game_state.signal, |gs| gs.state.game_status.clone());
-    let tournament_game_result = create_read_slice(game_state.signal, |gs| {
-        gs.game_response
+    let game_status = Signal::derive(move || game_state.state().get().game_status.clone());
+    let tournament_game_result = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
             .map(|gr| gr.tournament_game_result.clone())
     });
-    let game_conclusion = create_read_slice(game_state.signal, |gs| {
-        gs.game_response.as_ref().map(|gr| gr.conclusion.clone())
+    let game_conclusion = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
+            .as_ref()
+            .map(|gr| gr.conclusion.clone())
     });
-    let white_username = create_read_slice(game_state.signal, |gs| {
-        gs.game_response
+    let white_username = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
             .map(|gr| gr.white_player.username.clone())
             .unwrap_or_default()
     });
-    let black_username = create_read_slice(game_state.signal, |gs| {
-        gs.game_response
+    let black_username = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
             .map(|gr| gr.black_player.username.clone())
             .unwrap_or_default()
     });
-    let tournament_info = create_read_slice(game_state.signal, |gs| {
-        gs.game_response.as_ref().map(|gr| {
+    let tournament_info = Signal::derive(move || {
+        game_state.game_response().get().as_ref().map(|gr| {
             (
                 gr.tournament.is_some(),
                 gr.tournament.as_ref().map(|t| t.name.clone()),

--- a/apis/src/components/molecules/history_controls.rs
+++ b/apis/src/components/molecules/history_controls.rs
@@ -3,7 +3,7 @@ use crate::{
         atoms::history_button::{HistoryButton, HistoryNavigation},
         organisms::reserve::{Alignment, Reserve},
     },
-    providers::game_state::GameStateSignal,
+    providers::game_state::GameStateStore,
 };
 use hive_lib::Color;
 use leptos::{ev::keydown, html, prelude::*};
@@ -11,7 +11,7 @@ use leptos_use::{use_event_listener, use_window};
 
 #[component]
 pub fn HistoryControls(#[prop(optional)] parent: MaybeProp<NodeRef<html::Div>>) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let window = use_window();
     let active = Signal::derive_local(move || {
         window.as_ref().and_then(|w| {
@@ -47,11 +47,11 @@ pub fn HistoryControls(#[prop(optional)] parent: MaybeProp<NodeRef<html::Div>>) 
             let parent = parent.get_untracked().expect("div to be loaded");
             parent.set_scroll_top(parent.scroll_height());
         }
-        game_state.show_history_turn(game_state.signal.with_untracked(|gs| gs.state.turn - 1));
+        game_state.show_history_turn(game_state.with_untracked(|gs| gs.state.turn - 1));
     });
     let if_last_go_to_end = Callback::new(move |()| {
         focus.run(());
-        if game_state.signal.with_untracked(|gs| gs.is_last_turn()) {
+        if game_state.with_untracked(|gs| gs.is_last_turn()) {
             go_to_end.run(());
         }
     });

--- a/apis/src/components/molecules/history_pieces.rs
+++ b/apis/src/components/molecules/history_pieces.rs
@@ -1,7 +1,10 @@
 use crate::{
     common::HexStack,
     components::molecules::hex_stack::HexStack as HexStackView,
-    providers::{config::TileOptions, game_state::GameStateSignal},
+    providers::{
+        config::TileOptions,
+        game_state::{GameStateStore, GameStateStoreFields},
+    },
 };
 use hive_lib::{History, Position, State};
 use leptos::prelude::*;
@@ -11,10 +14,10 @@ pub fn HistoryPieces(
     tile_opts: TileOptions,
     target_stack: RwSignal<Option<Position>>,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
 
-    let history_turn = create_read_slice(game_state.signal, |gs| gs.history_turn);
-    let history_moves = create_read_slice(game_state.signal, |gs| gs.state.history.moves.clone());
+    let history_turn = Signal::derive(move || game_state.history_turn().get());
+    let history_moves = Signal::derive(move || game_state.state().get().history.moves.clone());
 
     let history_state = Memo::new(move |_| {
         history_moves.with(|moves| {

--- a/apis/src/components/molecules/live_timer.rs
+++ b/apis/src/components/molecules/live_timer.rs
@@ -1,5 +1,5 @@
 use crate::providers::{
-    game_state::GameStateSignal,
+    game_state::{GameStateStore, GameStateStoreFields},
     timer::TimerSignal,
     ApiRequestsProvider,
     AuthContext,
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 #[component]
 pub fn LiveTimer(side: Signal<Color>) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let sounds = expect_context::<Sounds>();
     let auth_context = expect_context::<AuthContext>();
     let api = expect_context::<ApiRequestsProvider>().0;
@@ -40,8 +40,10 @@ pub fn LiveTimer(side: Signal<Color>) -> impl IntoView {
             .with_untracked(|a| a.as_ref().map(|user| user.id))
     });
     let user_color = game_state.user_color_as_signal(user_id);
-    let in_progress = create_read_slice(game_state.signal, |gs| {
-        gs.game_response
+    let in_progress = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
             .is_some_and(|gr| gr.game_status == GameStatus::InProgress)
     });

--- a/apis/src/components/molecules/rating_and_change.rs
+++ b/apis/src/components/molecules/rating_and_change.rs
@@ -1,4 +1,7 @@
-use crate::{common::RatingChangeInfo, providers::game_state::GameStateSignal};
+use crate::{
+    common::RatingChangeInfo,
+    providers::game_state::{GameStateStore, GameStateStoreFields},
+};
 use hive_lib::Color;
 use leptos::prelude::*;
 use std::cmp::Ordering;
@@ -32,9 +35,11 @@ pub fn RatingAndChangeDynamic(
     #[prop(optional)] extend_tw_classes: &'static str,
     side: Color,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
-    let ratings = create_read_slice(game_state.signal, |gs| {
-        gs.game_response
+    let game_state = expect_context::<GameStateStore>();
+    let ratings = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
             .map(RatingChangeInfo::from_game_response)
     });

--- a/apis/src/components/molecules/user_with_rating.rs
+++ b/apis/src/components/molecules/user_with_rating.rs
@@ -7,7 +7,7 @@ use crate::{
         atoms::{profile_link::ProfileLink, rating::Rating, status_indicator::StatusIndicator},
         molecules::rating_and_change::RatingAndChangeDynamic,
     },
-    providers::game_state::GameStateSignal,
+    providers::game_state::{GameStateStore, GameStateStoreFields},
 };
 
 #[component]
@@ -16,8 +16,8 @@ pub fn UserWithRating(
     #[prop(optional)] text_color: &'static str,
     #[prop(optional)] vertical: bool,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
-    let game_response = create_read_slice(game_state.signal, |gs| gs.game_response.clone());
+    let game_state = expect_context::<GameStateStore>();
+    let game_response = Signal::derive(move || game_state.game_response().get());
     let player = Signal::derive(move || match side() {
         Color::White => game_response.with(|g| g.as_ref().map(|g| g.white_player.clone())),
         Color::Black => game_response.with(|g| g.as_ref().map(|g| g.black_player.clone())),

--- a/apis/src/components/organisms/analysis/atoms.rs
+++ b/apis/src/components/organisms/analysis/atoms.rs
@@ -78,6 +78,8 @@ pub fn HistoryButton(
 ) -> impl IntoView {
     let analysis = expect_context::<AnalysisStore>();
     let game_state = expect_context::<GameStateStore>();
+    let current_node = analysis.current_node();
+    let tree = analysis.tree();
     let cloned_action = action.clone();
     let nav_buttons_style = "flex place-items-center justify-center hover:bg-pillbug-teal dark:hover:bg-pillbug-teal transform transition-transform duration-300 active:scale-95 m-1 h-7 rounded-md border-cyan-500 dark:border-button-twilight border-2 drop-shadow-lg disabled:opacity-25 disabled:cursor-not-allowed disabled:hover:bg-transparent";
     let icon = match action {
@@ -87,32 +89,31 @@ pub fn HistoryButton(
     };
 
     let is_disabled = move || {
-        analysis.0.with(|analysis_tree| {
-            if let Some(n) = &analysis_tree.current_node {
-                match cloned_action {
-                    HistoryNavigation::First => n.get_node_id().map_or(true, |node_id| {
+        if let Some(n) = current_node.get() {
+            match cloned_action {
+                HistoryNavigation::First => n.get_node_id().map_or(true, |node_id| {
+                    tree.with(|analysis_tree| {
                         analysis_tree
-                            .tree
                             .get_ancestor_ids(&node_id)
                             .map_or(true, |ids| ids.is_empty())
-                    }),
-                    HistoryNavigation::Next => n
-                        .get_children_ids()
-                        .map_or(true, |children| children.is_empty()),
-                    HistoryNavigation::Previous => n.get_parent_id().map_or(true, |p| p.is_none()),
-                }
-            } else {
-                false
+                    })
+                }),
+                HistoryNavigation::Next => n
+                    .get_children_ids()
+                    .map_or_else(|_| true, |children| children.is_empty()),
+                HistoryNavigation::Previous => n.get_parent_id().map_or(true, |p| p.is_none()),
             }
-        })
+        } else {
+            false
+        }
     };
     let debounced_action = debounce(std::time::Duration::from_millis(10), move |_| {
-        let updated_node_id = analysis.0.with(|a| {
-            a.current_node.as_ref().and_then(|n| match action {
+        let updated_node_id = current_node.with_untracked(|a| {
+            a.as_ref().and_then(|n| match action {
                 HistoryNavigation::First => n
                     .get_node_id()
                     .ok()
-                    .and_then(|node_id| a.tree.get_ancestor_ids(&node_id).ok())
+                    .and_then(|node_id| tree.with_untracked(|t| t.get_ancestor_ids(&node_id).ok()))
                     .and_then(|ids| ids.last().cloned()),
                 HistoryNavigation::Next => n
                     .get_children_ids()
@@ -135,7 +136,7 @@ pub fn HistoryButton(
         <button
             node_ref=_definite_node_ref
             class=nav_buttons_style
-            prop:disabled=is_disabled
+            disabled=is_disabled
             on:click=debounced_action
         >
 

--- a/apis/src/components/organisms/analysis/atoms.rs
+++ b/apis/src/components/organisms/analysis/atoms.rs
@@ -1,7 +1,7 @@
 use crate::{
     pages::analysis::ToggleStates,
     providers::{
-        analysis::{AnalysisSignal, TreeNode},
+        analysis::{AnalysisStore, AnalysisTreeStoreFields, TreeNode},
         game_state::{GameStateStore, GameStateStoreFields},
     },
 };
@@ -11,16 +11,24 @@ use tree_ds::prelude::Node;
 
 #[component]
 pub fn UndoButton() -> impl IntoView {
-    let analysis = expect_context::<AnalysisSignal>();
+    let analysis = expect_context::<AnalysisStore>();
     let game_state = expect_context::<GameStateStore>();
-    let analysis = StoredValue::new(analysis.clone());
-    let is_disabled = move || analysis.get_value().0.with(|a| a.current_node.is_none());
+    let disabled_analysis = analysis.clone();
+    let is_disabled = move || disabled_analysis.current_node().get().is_none();
     let undo = move |_| {
-        analysis.get_value().0.update(|a| {
+        let mut needs_sync = false;
+        analysis.update(|a| {
             if let Some(node) = &a.current_node {
                 if let Ok(node_id) = node.get_node_id() {
                     if let Ok(Some(new_current)) = node.get_parent_id() {
-                        a.update_node(new_current, Some(game_state));
+                        while let Some(v) = a.full_path.last() {
+                            if v != &node_id {
+                                a.full_path.pop();
+                            }
+                        }
+                        a.full_path.pop();
+                        a.current_node = a.tree.get_node_by_id(&new_current);
+                        needs_sync = true;
                         if let Ok(tree) = a.tree.get_subtree(&node_id, None) {
                             tree.get_nodes().iter().for_each(|n| {
                                 if let Ok(n_id) = n.get_node_id() {
@@ -38,6 +46,9 @@ pub fn UndoButton() -> impl IntoView {
                 }
             }
         });
+        if needs_sync {
+            analysis.sync_game_state(game_state);
+        }
     };
 
     view! {
@@ -65,7 +76,7 @@ pub fn HistoryButton(
     post_action: Option<Callback<()>>,
     #[prop(optional)] node_ref: Option<NodeRef<html::Button>>,
 ) -> impl IntoView {
-    let analysis = expect_context::<AnalysisSignal>().0;
+    let analysis = expect_context::<AnalysisStore>();
     let game_state = expect_context::<GameStateStore>();
     let cloned_action = action.clone();
     let nav_buttons_style = "flex place-items-center justify-center hover:bg-pillbug-teal dark:hover:bg-pillbug-teal transform transition-transform duration-300 active:scale-95 m-1 h-7 rounded-md border-cyan-500 dark:border-button-twilight border-2 drop-shadow-lg disabled:opacity-25 disabled:cursor-not-allowed disabled:hover:bg-transparent";
@@ -76,11 +87,11 @@ pub fn HistoryButton(
     };
 
     let is_disabled = move || {
-        analysis.with(|analysis| {
-            if let Some(n) = &analysis.current_node {
+        analysis.0.with(|analysis_tree| {
+            if let Some(n) = &analysis_tree.current_node {
                 match cloned_action {
                     HistoryNavigation::First => n.get_node_id().map_or(true, |node_id| {
-                        analysis
+                        analysis_tree
                             .tree
                             .get_ancestor_ids(&node_id)
                             .map_or(true, |ids| ids.is_empty())
@@ -96,7 +107,7 @@ pub fn HistoryButton(
         })
     };
     let debounced_action = debounce(std::time::Duration::from_millis(10), move |_| {
-        let updated_node_id = analysis.with(|a| {
+        let updated_node_id = analysis.0.with(|a| {
             a.current_node.as_ref().and_then(|n| match action {
                 HistoryNavigation::First => n
                     .get_node_id()
@@ -111,9 +122,8 @@ pub fn HistoryButton(
             })
         });
         if let Some(updated_node_id) = updated_node_id {
-            analysis.update(|a| {
-                a.update_node(updated_node_id, Some(game_state));
-            });
+            analysis.update_node(updated_node_id);
+            analysis.sync_game_state(game_state);
         }
         if let Some(post_action) = post_action {
             post_action.run(())
@@ -140,12 +150,14 @@ pub fn HistoryMove(
     current_path: Memo<Vec<i32>>,
     has_children: bool,
 ) -> impl IntoView {
-    let analysis = expect_context::<AnalysisSignal>().0;
+    let analysis = expect_context::<AnalysisStore>();
     let game_state = expect_context::<GameStateStore>();
     if let (Ok(Some(value)), Ok(node_id)) = (node.get_value(), node.get_node_id()) {
+        let is_current =
+            Signal::derive(move || analysis.current_node().get().is_some_and(|c| c == node));
         let class = move || {
             let margin = if has_children { "" } else { "ml-[15px] " };
-            let bg_color = if current_path.with(|path| path.first() == Some(&node_id)) {
+            let bg_color = if is_current() {
                 "bg-orange-twilight "
             } else {
                 ""
@@ -153,9 +165,8 @@ pub fn HistoryMove(
             format!("{margin}w-fit transition-transform duration-300 transform hover:bg-pillbug-teal dark:hover:bg-pillbug-teal {bg_color}active:scale-95")
         };
         let onclick = move |_| {
-            analysis.update(|a| {
-                a.update_node(node_id, Some(game_state));
-            });
+            analysis.update_node(node_id);
+            analysis.sync_game_state(game_state);
         };
         let history_index = value.turn - 1;
         let game_state = expect_context::<GameStateStore>();

--- a/apis/src/components/organisms/analysis/atoms.rs
+++ b/apis/src/components/organisms/analysis/atoms.rs
@@ -2,7 +2,7 @@ use crate::{
     pages::analysis::ToggleStates,
     providers::{
         analysis::{AnalysisSignal, TreeNode},
-        game_state::GameStateSignal,
+        game_state::{GameStateStore, GameStateStoreFields},
     },
 };
 use leptos::{html, prelude::*};
@@ -12,7 +12,7 @@ use tree_ds::prelude::Node;
 #[component]
 pub fn UndoButton() -> impl IntoView {
     let analysis = expect_context::<AnalysisSignal>();
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let analysis = StoredValue::new(analysis.clone());
     let is_disabled = move || analysis.get_value().0.with(|a| a.current_node.is_none());
     let undo = move |_| {
@@ -66,7 +66,7 @@ pub fn HistoryButton(
     #[prop(optional)] node_ref: Option<NodeRef<html::Button>>,
 ) -> impl IntoView {
     let analysis = expect_context::<AnalysisSignal>().0;
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let cloned_action = action.clone();
     let nav_buttons_style = "flex place-items-center justify-center hover:bg-pillbug-teal dark:hover:bg-pillbug-teal transform transition-transform duration-300 active:scale-95 m-1 h-7 rounded-md border-cyan-500 dark:border-button-twilight border-2 drop-shadow-lg disabled:opacity-25 disabled:cursor-not-allowed disabled:hover:bg-transparent";
     let icon = match action {
@@ -141,7 +141,7 @@ pub fn HistoryMove(
     has_children: bool,
 ) -> impl IntoView {
     let analysis = expect_context::<AnalysisSignal>().0;
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     if let (Ok(Some(value)), Ok(node_id)) = (node.get_value(), node.get_node_id()) {
         let class = move || {
             let margin = if has_children { "" } else { "ml-[15px] " };
@@ -158,9 +158,8 @@ pub fn HistoryMove(
             });
         };
         let history_index = value.turn - 1;
-        let game_state = expect_context::<GameStateSignal>();
-        let repetitions =
-            create_read_slice(game_state.signal, |gs| gs.state.repeating_moves.clone());
+        let game_state = expect_context::<GameStateStore>();
+        let repetitions = Signal::derive(move || game_state.state().get().repeating_moves.clone());
         let rep = move || {
             if repetitions.with(|r| r.contains(&history_index))
                 && current_path.with(|p| p.contains(&node_id))

--- a/apis/src/components/organisms/analysis/history.rs
+++ b/apis/src/components/organisms/analysis/history.rs
@@ -205,7 +205,6 @@ pub fn History(#[prop(optional)] mobile: bool) -> impl IntoView {
                     }
                 }
             }
-            a.recompute_full_path_from_current();
         });
     };
 
@@ -213,12 +212,13 @@ pub fn History(#[prop(optional)] mobile: bool) -> impl IntoView {
     let next_button = NodeRef::<html::Button>::new();
     Effect::new(move |_| {
         _ = use_event_listener(document().body(), keydown, move |evt| {
-            if evt.key() == "ArrowLeft" {
+            let has_modifier = evt.alt_key() || evt.ctrl_key() || evt.meta_key() || evt.shift_key();
+            if !has_modifier && evt.key() == "ArrowLeft" {
                 evt.prevent_default();
                 if let Some(prev) = prev_button.get_untracked() {
                     prev.click()
                 }
-            } else if evt.key() == "ArrowRight" {
+            } else if !has_modifier && evt.key() == "ArrowRight" {
                 evt.prevent_default();
                 if let Some(next) = next_button.get_untracked() {
                     next.click()

--- a/apis/src/components/organisms/analysis/history.rs
+++ b/apis/src/components/organisms/analysis/history.rs
@@ -8,11 +8,12 @@ use crate::{
         },
         reserve::{Alignment, Reserve},
     },
-    providers::analysis::{AnalysisSignal, AnalysisTree, TreeNode},
+    providers::analysis::{AnalysisStore, AnalysisTree, TreeNode},
 };
 use hive_lib::Color;
 use leptos::{ev::keydown, html, prelude::*};
 use leptos_use::{use_event_listener, use_window};
+use reactive_stores::Store;
 use std::{cmp::Ordering, collections::HashMap};
 use tree_ds::prelude::*;
 
@@ -113,7 +114,7 @@ fn build_history_model(tree: &Tree<i32, TreeNode>) -> Option<Vec<HistoryItem>> {
 
 fn render_history_items(
     items: &[HistoryItem],
-    analysis: RwSignal<AnalysisTree>,
+    analysis: Store<AnalysisTree>,
     current_path: Memo<Vec<i32>>,
 ) -> AnyView {
     items
@@ -148,7 +149,7 @@ fn render_history_items(
 
 #[component]
 pub fn History(#[prop(optional)] mobile: bool) -> impl IntoView {
-    let analysis = expect_context::<AnalysisSignal>().0;
+    let analysis = expect_context::<AnalysisStore>().0;
     let current_path = Memo::new(move |_| {
         analysis.with(|a| {
             a.current_node
@@ -204,6 +205,7 @@ pub fn History(#[prop(optional)] mobile: bool) -> impl IntoView {
                     }
                 }
             }
+            a.recompute_full_path_from_current();
         });
     };
 

--- a/apis/src/components/organisms/analysis/save_and_load.rs
+++ b/apis/src/components/organisms/analysis/save_and_load.rs
@@ -1,6 +1,6 @@
 use crate::providers::{
     analysis::{AnalysisSignal, AnalysisTree},
-    game_state::GameStateSignal,
+    game_state::GameStateStore,
 };
 use hive_lib::History;
 use leptos::{html, logging, prelude::*};
@@ -63,7 +63,7 @@ fn blob_and_filename(tree: String) -> (Blob, String) {
 #[component]
 pub fn LoadTree() -> impl IntoView {
     let analysis = expect_context::<AnalysisSignal>().0;
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let input_ref = NodeRef::<html::Input>::new();
 
     let from_pgn = move |string: JsValue| {
@@ -72,7 +72,7 @@ pub fn LoadTree() -> impl IntoView {
             .and_then(|string| History::from_pgn_str(string).ok())
             .and_then(|history| hive_lib::State::new_from_history(&history).ok())
             .map(|state| {
-                game_state.signal.update(|gs| gs.state = state.clone());
+                game_state.update(|gs| gs.state = state.clone());
                 let tree = AnalysisTree::from_loaded_state(game_state, &state);
                 analysis.set(tree);
             })

--- a/apis/src/components/organisms/analysis/save_and_load.rs
+++ b/apis/src/components/organisms/analysis/save_and_load.rs
@@ -1,5 +1,5 @@
 use crate::providers::{
-    analysis::{AnalysisSignal, AnalysisTree},
+    analysis::{AnalysisStore, AnalysisTree},
     game_state::GameStateStore,
 };
 use hive_lib::History;
@@ -13,7 +13,7 @@ const BTN_CLASS: &str = "z-20 content-center text-center m-1 w-1/3 h-7 text-whit
 
 #[component]
 pub fn DownloadTree() -> impl IntoView {
-    let analysis = expect_context::<AnalysisSignal>().0;
+    let analysis = expect_context::<AnalysisStore>().0;
 
     let download = move |_| {
         let tree_json = analysis.with_untracked(|a| {
@@ -22,6 +22,7 @@ pub fn DownloadTree() -> impl IntoView {
                 tree: a.tree.clone(),
                 hashes: a.hashes.clone(),
                 game_type: a.game_type,
+                full_path: a.full_path.clone(),
             };
             serde_json::to_string(&out).unwrap()
         });
@@ -62,36 +63,9 @@ fn blob_and_filename(tree: String) -> (Blob, String) {
 
 #[component]
 pub fn LoadTree() -> impl IntoView {
-    let analysis = expect_context::<AnalysisSignal>().0;
+    let analysis = expect_context::<AnalysisStore>();
     let game_state = expect_context::<GameStateStore>();
     let input_ref = NodeRef::<html::Input>::new();
-
-    let from_pgn = move |string: JsValue| {
-        string
-            .as_string()
-            .and_then(|string| History::from_pgn_str(string).ok())
-            .and_then(|history| hive_lib::State::new_from_history(&history).ok())
-            .map(|state| {
-                game_state.update(|gs| gs.state = state.clone());
-                let tree = AnalysisTree::from_loaded_state(game_state, &state);
-                analysis.set(tree);
-            })
-    };
-    let from_json = move |string: JsValue| {
-        string
-            .as_string()
-            .and_then(|string| serde_json::from_str::<AnalysisTree>(&string).ok())
-            .map(|tree| {
-                analysis.set(tree.clone());
-                if let Some(node) = tree.current_node {
-                    if let Ok(node_id) = node.get_node_id() {
-                        analysis.update(|a| {
-                            a.update_node(node_id, Some(game_state));
-                        });
-                    }
-                }
-            })
-    };
     let oninput = move |_| {
         let file = input_ref
             .get_untracked()
@@ -104,12 +78,40 @@ pub fn LoadTree() -> impl IntoView {
             || logging::log!("Couldn't open file"),
             |ext| {
                 let ext = ext.to_os_string();
+                let analysis = analysis.clone();
                 spawn_local(async move {
                     let text = JsFuture::from(file.text()).await.ok();
                     let result = if ext == "json" {
-                        text.and_then(from_json)
+                        text.and_then(|value: JsValue| {
+                            value
+                                .as_string()
+                                .and_then(|string| {
+                                    serde_json::from_str::<AnalysisTree>(&string).ok()
+                                })
+                                .map(|tree| {
+                                    analysis.0.set(tree.clone());
+                                    if let Some(node) = tree.current_node {
+                                        if let Ok(node_id) = node.get_node_id() {
+                                            analysis.update_node(node_id);
+                                            analysis.sync_game_state(game_state);
+                                        }
+                                    }
+                                })
+                        })
                     } else if ext == "pgn" {
-                        text.and_then(from_pgn)
+                        text.and_then(|value: JsValue| {
+                            value
+                                .as_string()
+                                .and_then(|string| History::from_pgn_str(string).ok())
+                                .and_then(|history| {
+                                    hive_lib::State::new_from_history(&history).ok()
+                                })
+                                .map(|state| {
+                                    game_state.update(|gs| gs.state = state.clone());
+                                    let tree = AnalysisTree::from_loaded_state(game_state, &state);
+                                    analysis.0.set(tree);
+                                })
+                        })
                     } else {
                         logging::log!("Unsupported file type");
                         None

--- a/apis/src/components/organisms/analysis/save_and_load.rs
+++ b/apis/src/components/organisms/analysis/save_and_load.rs
@@ -1,6 +1,6 @@
 use crate::providers::{
     analysis::{AnalysisStore, AnalysisTree},
-    game_state::GameStateStore,
+    game_state::{GameStateStore, GameStateStoreFields},
 };
 use hive_lib::History;
 use leptos::{html, logging, prelude::*};
@@ -79,6 +79,7 @@ pub fn LoadTree() -> impl IntoView {
             |ext| {
                 let ext = ext.to_os_string();
                 let analysis = analysis.clone();
+                let game_state = game_state.clone();
                 spawn_local(async move {
                     let text = JsFuture::from(file.text()).await.ok();
                     let result = if ext == "json" {
@@ -88,14 +89,20 @@ pub fn LoadTree() -> impl IntoView {
                                 .and_then(|string| {
                                     serde_json::from_str::<AnalysisTree>(&string).ok()
                                 })
-                                .map(|tree| {
-                                    analysis.0.set(tree.clone());
-                                    if let Some(node) = tree.current_node {
-                                        if let Ok(node_id) = node.get_node_id() {
-                                            analysis.update_node(node_id);
-                                            analysis.sync_game_state(game_state);
-                                        }
+                                .map(|mut tree| {
+                                    let loaded_current_node_id = tree
+                                        .current_node
+                                        .as_ref()
+                                        .and_then(|node| node.get_node_id().ok());
+                                    if let Some(node_id) = loaded_current_node_id {
+                                        tree.current_node = tree.tree.get_node_by_id(&node_id);
                                     }
+                                    tree.recompute_full_path_from_current();
+                                    if let Some((state, turn)) = tree.state_and_turn_for_node() {
+                                        game_state.history_turn().set(turn);
+                                        game_state.state().set(state);
+                                    }
+                                    analysis.set(tree);
                                 })
                         })
                     } else if ext == "pgn" {
@@ -107,9 +114,12 @@ pub fn LoadTree() -> impl IntoView {
                                     hive_lib::State::new_from_history(&history).ok()
                                 })
                                 .map(|state| {
-                                    game_state.update(|gs| gs.state = state.clone());
-                                    let tree = AnalysisTree::from_loaded_state(game_state, &state);
+                                    let tree = AnalysisTree::from_loaded_state(&state, None);
                                     analysis.0.set(tree);
+                                    game_state
+                                        .history_turn()
+                                        .set(Some(state.history.moves.len()));
+                                    game_state.state().set(state);
                                 })
                         })
                     } else {

--- a/apis/src/components/organisms/board.rs
+++ b/apis/src/components/organisms/board.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     providers::{
         analysis::AnalysisSignal,
-        game_state::{GameStateSignal, View},
+        game_state::{GameStateStore, GameStateStoreFields, View},
         Config,
     },
 };
@@ -123,7 +123,7 @@ impl ViewBoxState {
 
 #[component]
 pub fn Board() -> impl IntoView {
-    let mut game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let analysis = use_context::<AnalysisSignal>();
     let orientation_signal = expect_context::<OrientationSignal>();
     let target_stack = RwSignal::new(None);
@@ -136,8 +136,8 @@ pub fn Board() -> impl IntoView {
     let g_ref = NodeRef::<svg::G>::new();
     let div_ref = NodeRef::<html::Div>::new();
     let last_turn = game_state.is_last_turn_as_signal();
-    let board_view = create_read_slice(game_state.signal, |gs| gs.view.clone());
-    let game_status = create_read_slice(game_state.signal, |gs| gs.state.game_status.clone());
+    let board_view = Signal::derive(move || game_state.view().get());
+    let game_status = Signal::derive(move || game_state.state().get().game_status.clone());
     let board_style = move || {
         if orientation_signal.orientation_vertical.get() {
             "flex grow min-h-0"
@@ -166,9 +166,7 @@ pub fn Board() -> impl IntoView {
         viewbox_signal.with(|vb| format!("translate({},{})", vb.x_transform, vb.y_transform))
     };
 
-    let current_center = game_state
-        .signal
-        .with_untracked(|gs| gs.state.board.center_coordinates());
+    let current_center = game_state.with_untracked(|gs| gs.state.board.center_coordinates());
 
     let straight = config.with_untracked(|c| c.tile.design == TileDesign::ThreeD);
     let tile_opts = Signal::derive(move || config.with(|c| c.tile.clone()));

--- a/apis/src/components/organisms/board.rs
+++ b/apis/src/components/organisms/board.rs
@@ -5,7 +5,7 @@ use crate::{
         molecules::{board_pieces::BoardPieces, history_pieces::HistoryPieces},
     },
     providers::{
-        analysis::AnalysisSignal,
+        analysis::AnalysisStore,
         game_state::{GameStateStore, GameStateStoreFields, View},
         Config,
     },
@@ -124,7 +124,7 @@ impl ViewBoxState {
 #[component]
 pub fn Board() -> impl IntoView {
     let game_state = expect_context::<GameStateStore>();
-    let analysis = use_context::<AnalysisSignal>();
+    let analysis = use_context::<AnalysisStore>();
     let orientation_signal = expect_context::<OrientationSignal>();
     let target_stack = RwSignal::new(None);
     let config = expect_context::<Config>().0;

--- a/apis/src/components/organisms/chat.rs
+++ b/apis/src/components/organisms/chat.rs
@@ -1,6 +1,10 @@
 use crate::{
     components::update_from_event::update_from_input,
-    providers::{chat::Chat, game_state::GameStateSignal, AuthContext},
+    providers::{
+        chat::Chat,
+        game_state::{GameStateStore, GameStateStoreFields},
+        AuthContext,
+    },
 };
 use chrono::Local;
 use leptos::{html, prelude::*};
@@ -34,8 +38,8 @@ pub fn Message(message: ChatMessage) -> impl IntoView {
 #[component]
 pub fn ChatInput(destination: Signal<ChatDestination>) -> impl IntoView {
     let chat = expect_context::<Chat>();
-    let game_state = use_context::<GameStateSignal>();
-    let turn = move || game_state.map(|gs| gs.signal.with(|state| state.state.turn));
+    let game_state = use_context::<GameStateStore>();
+    let turn = move || game_state.map(|gs| gs.with(|state| state.state.turn));
     let send = move || {
         let message = chat.typed_message.get();
         if !message.is_empty() {
@@ -88,12 +92,12 @@ pub fn ChatWindow(
     };
     let chat = expect_context::<Chat>();
     let auth_context = expect_context::<AuthContext>();
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let uid = auth_context
         .user
         .with_untracked(|a| a.as_ref().map(|user| user.user.uid));
-    let white_id = create_read_slice(game_state.signal, |gs| gs.white_id);
-    let black_id = create_read_slice(game_state.signal, |gs| gs.black_id);
+    let white_id = Signal::derive(move || game_state.white_id().get());
+    let black_id = Signal::derive(move || game_state.black_id().get());
     let white_id = move || white_id().expect("Game has white player");
     let black_id = move || black_id().expect("Game has black player");
 
@@ -115,7 +119,7 @@ pub fn ChatWindow(
 
     let actual_destination = Signal::derive(move || match destination.clone() {
         SimpleDestination::Game => {
-            if game_state.signal.with(|gs| gs.uid_is_player(uid)) {
+            if game_state.with(|gs| gs.uid_is_player(uid)) {
                 ChatDestination::GamePlayers(game_id(), white_id(), black_id())
             } else {
                 ChatDestination::GameSpectators(game_id(), white_id(), black_id())

--- a/apis/src/components/organisms/display_timer.rs
+++ b/apis/src/components/organisms/display_timer.rs
@@ -3,7 +3,7 @@ use crate::{
     components::molecules::{live_timer::LiveTimer, user_with_rating::UserWithRating},
     pages::play::CurrentConfirm,
     providers::{
-        game_state::GameStateSignal,
+        game_state::{GameStateStore, GameStateStoreFields},
         timer::TimerSignal,
         ApiRequestsProvider,
         AuthContext,
@@ -22,12 +22,12 @@ pub enum Placement {
 
 #[component]
 pub fn DisplayTimer(placement: Placement, vertical: bool) -> impl IntoView {
-    let mut game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let auth_context = expect_context::<AuthContext>();
     let current_confirm = expect_context::<CurrentConfirm>().0;
     let user = auth_context.user;
 
-    let black_id = create_read_slice(game_state.signal, |gs| gs.black_id);
+    let black_id = Signal::derive(move || game_state.black_id().get());
     let player_is_black =
         Memo::new(move |_| user().is_some_and(|user| Some(user.id) == black_id()));
     let side = Signal::derive(move || match (player_is_black(), placement) {

--- a/apis/src/components/organisms/history.rs
+++ b/apis/src/components/organisms/history.rs
@@ -5,7 +5,7 @@ use crate::{
         organisms::side_board::move_query_signal,
     },
     providers::{
-        game_state::{self, GameStateSignal},
+        game_state::{GameStateStore, GameStateStoreFields},
         timer::TimerSignal,
     },
 };
@@ -25,22 +25,20 @@ pub fn HistoryMove(
     repetition: bool,
     parent_div: NodeRef<html::Div>,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let div_ref = NodeRef::<html::Div>::new();
     let timer = expect_context::<TimerSignal>();
     let (_move, set_move) = move_query_signal();
     let onclick = move |_| {
         game_state.show_history_turn(turn);
-        set_move.set(
-            game_state
-                .signal
-                .with_untracked(|gs| gs.history_turn.map(|v| v + 1)),
-        );
+        set_move.set(game_state.with_untracked(|gs| gs.history_turn.map(|v| v + 1)));
         set_timer_from_response(game_state, timer);
     };
-    let history_turn = create_read_slice(game_state.signal, |gs| gs.history_turn);
-    let is_realtime = create_read_slice(game_state.signal, |gs| {
-        gs.game_response
+    let history_turn = Signal::derive(move || game_state.history_turn().get());
+    let is_realtime = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
             .is_some_and(|gr| gr.time_mode == TimeMode::RealTime)
     });
@@ -70,7 +68,7 @@ pub fn HistoryMove(
         if turn < 2 {
             return None;
         }
-        let response = game_state.signal.with(|gs| gs.game_response.clone())?;
+        let response = game_state.game_response().get()?;
         let increment = response.time_increment? as i64 * NANOS_IN_SECOND as i64;
         let time_left = (*response.move_times.get(turn)?)?;
         let prev_time = (*response.move_times.get(turn - 2)?)?;
@@ -91,12 +89,16 @@ pub fn HistoryMove(
 
 #[component]
 pub fn History(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
-    let game_state = expect_context::<game_state::GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let params = use_params_map();
     let queries = use_query_map();
-    let state = create_read_slice(game_state.signal, |gs| gs.state.clone());
-    let repetitions = create_read_slice(game_state.signal, |gs| {
-        gs.game_response.as_ref().map(|gr| gr.repetitions.clone())
+    let state = Signal::derive(move || game_state.state().get());
+    let repetitions = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
+            .as_ref()
+            .map(|gr| gr.repetitions.clone())
     });
     let history_moves = move || {
         state()
@@ -114,8 +116,8 @@ pub fn History(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoVi
         _ => "".to_string(),
     };
 
-    let conclusion = create_read_slice(game_state.signal, |gs| {
-        if let Some(game) = &gs.game_response {
+    let conclusion = Signal::derive(move || {
+        if let Some(game) = &game_state.game_response().get() {
             game.conclusion.pretty_string()
         } else {
             String::from("No data")

--- a/apis/src/components/organisms/reserve.rs
+++ b/apis/src/components/organisms/reserve.rs
@@ -6,7 +6,7 @@ use crate::{
         hex_stack::HexStack,
     },
     providers::{
-        analysis::AnalysisSignal,
+        analysis::AnalysisStore,
         game_state::{GameStateStore, GameStateStoreFields, View},
         AuthContext,
         Config,
@@ -70,7 +70,7 @@ pub fn Reserve(
     #[prop(optional)] extend_tw_classes: &'static str,
     #[prop(optional)] viewbox_str: Option<&'static str>,
 ) -> impl IntoView {
-    let analysis = use_context::<AnalysisSignal>().is_some();
+    let analysis = use_context::<AnalysisStore>().is_some();
     let game_state = expect_context::<GameStateStore>();
     let auth_context = expect_context::<AuthContext>();
     let config = expect_context::<Config>().0;

--- a/apis/src/components/organisms/reserve.rs
+++ b/apis/src/components/organisms/reserve.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     providers::{
         analysis::AnalysisSignal,
-        game_state::{GameStateSignal, View},
+        game_state::{GameStateStore, GameStateStoreFields, View},
         AuthContext,
         Config,
     },
@@ -71,7 +71,7 @@ pub fn Reserve(
     #[prop(optional)] viewbox_str: Option<&'static str>,
 ) -> impl IntoView {
     let analysis = use_context::<AnalysisSignal>().is_some();
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let auth_context = expect_context::<AuthContext>();
     let config = expect_context::<Config>().0;
     let tile_opts = Signal::derive(move || config().tile);
@@ -86,13 +86,15 @@ pub fn Reserve(
         }
     };
     // TODO: Should be a Store, this is hacky
-    let board_view = create_read_slice(game_state.signal, |gs| gs.view.clone());
-    let move_info = create_read_slice(game_state.signal, |gs| gs.move_info.clone());
-    let history_turn = create_read_slice(game_state.signal, |gs| gs.history_turn);
-    let state = create_read_slice(game_state.signal, |gs| gs.state.clone());
+    let board_view = Signal::derive(move || game_state.view().get());
+    let move_info = Signal::derive(move || game_state.move_info().get());
+    let history_turn = Signal::derive(move || game_state.history_turn().get());
+    let state = Signal::derive(move || game_state.state().get());
     let last_turn = game_state.is_last_turn_as_signal();
-    let status = create_read_slice(game_state.signal, |gs| {
-        gs.game_response
+    let status = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
             .map_or(GameStatus::NotStarted, |g| g.game_status.clone())
     });
@@ -102,8 +104,10 @@ pub fn Reserve(
             .with_untracked(|a| a.as_ref().map(|user| user.id))
     });
     let user_color = game_state.user_color_as_signal(user_id);
-    let tournament = create_read_slice(game_state.signal, |gs| {
-        gs.game_response
+    let tournament = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
             .is_some_and(|gr| gr.tournament.is_some())
     });

--- a/apis/src/components/organisms/side_board.rs
+++ b/apis/src/components/organisms/side_board.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     providers::{
         chat::Chat,
-        game_state::{GameStateSignal, View},
+        game_state::{GameStateStore, GameStateStoreFields, View},
         AuthContext,
     },
 };
@@ -41,20 +41,20 @@ fn TriggerButton(name: TabView, tab: RwSignal<TabView>) -> impl IntoView {
         TabView::History => "History".to_string(),
         TabView::Chat => "Chat".to_string(),
     };
-    let mut game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     view! {
         <div
             on:click=move |_| {
                 if tab() == TabView::Chat {
                     chat.seen_messages(game_id());
-                    let is_game_view = game_state.signal.with_untracked(|gs| gs.view == View::Game);
+                    let is_game_view = game_state.with_untracked(|gs| gs.view == View::Game);
                     if is_game_view {
                         set_move.set(None);
                     }
                 }
                 if name == TabView::History {
                     game_state.view_history();
-                    let history_turn = game_state.signal.with_untracked(|gs| gs.history_turn);
+                    let history_turn = game_state.with_untracked(|gs| gs.history_turn);
                     set_move.set(history_turn.map(|v| v + 1));
                 } else if name == TabView::Reserve {
                     game_state.view_game();
@@ -87,10 +87,11 @@ pub fn SideboardTabs(
     tab: RwSignal<TabView>,
     #[prop(optional)] extend_tw_classes: &'static str,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let auth_context = expect_context::<AuthContext>();
     let user = auth_context.user;
-    let white_and_black = create_read_slice(game_state.signal, |gs| (gs.white_id, gs.black_id));
+    let white_and_black =
+        Signal::derive(move || (game_state.white_id().get(), game_state.black_id().get()));
     let show_buttons = Signal::derive(move || {
         user().is_some_and(|user| {
             let (white_id, black_id) = white_and_black();

--- a/apis/src/components/organisms/unstarted.rs
+++ b/apis/src/components/organisms/unstarted.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use crate::{
     components::layouts::base_layout::OrientationSignal,
     i18n::*,
-    providers::{game_state::GameStateSignal, ApiRequestsProvider},
+    providers::{
+        game_state::{GameStateStore, GameStateStoreFields},
+        ApiRequestsProvider,
+    },
 };
 use leptos::prelude::*;
 use leptos_icons::*;
@@ -19,17 +22,21 @@ pub fn Unstarted(
 ) -> impl IntoView {
     let i18n = use_i18n();
     let api = expect_context::<ApiRequestsProvider>().0;
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let orientation_signal = expect_context::<OrientationSignal>();
-    let white = create_read_slice(game_state.signal, |gs| {
-        (gs.game_response
+    let white = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
-            .map(|gr| gr.white_player.username.clone()),)
+            .map(|gr| gr.white_player.username.clone())
     });
-    let black = create_read_slice(game_state.signal, |gs| {
-        (gs.game_response
+    let black = Signal::derive(move || {
+        game_state
+            .game_response()
+            .get()
             .as_ref()
-            .map(|gr| gr.black_player.username.clone()),)
+            .map(|gr| gr.black_player.username.clone())
     });
     let icon_for_color = move |id: Option<Uuid>| {
         let ready_map = ready.get();

--- a/apis/src/pages/analysis.rs
+++ b/apis/src/pages/analysis.rs
@@ -11,7 +11,7 @@ use crate::{
     functions::games::get::get_game_from_nanoid,
     pages::play::CurrentConfirm,
     providers::{
-        analysis::{AnalysisSignal, AnalysisTree, TreeNode},
+        analysis::{AnalysisStore, AnalysisTree, TreeNode},
         game_state::GameStateStore,
         AuthContext,
     },
@@ -20,6 +20,7 @@ use crate::{
 use hive_lib::{Color, GameStatus, GameType};
 use leptos::prelude::*;
 use leptos_router::hooks::{use_params_map, use_query_map};
+use reactive_stores::Store;
 use shared_types::{GameId, TimeMode};
 use std::collections::HashSet;
 
@@ -58,11 +59,31 @@ pub fn Analysis(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoV
                 || Some(user_id) == Some(game_response.black_player.uid))
     };
 
-    let game_resource = Resource::new(game_id, move |game_id| async move {
-        if let Some(game_id) = game_id {
+    let game_resource = OnceResource::new(async move {
+        if let Some(game_id) = game_id.get() {
             get_game_from_nanoid(game_id).await
         } else {
             Err(leptos::prelude::ServerFnError::new("No game ID provided"))
+        }
+    });
+    let analysis_signal = AnalysisStore(Store::new(
+        uhp_string
+            .get_value()
+            .and_then(|uhp| AnalysisTree::from_uhp(game_state, uhp).ok())
+            .unwrap_or_else(|| AnalysisTree::new_blank_analysis(game_state, GameType::MLP)),
+    ));
+    provide_context(analysis_signal.clone());
+    Effect::new(move |_| {
+        if let Some(Ok(game_response)) = game_resource.get() {
+            if should_block_analysis(&game_response) {
+                return;
+            }
+            if let Some(analysis_tree) =
+                AnalysisTree::from_game_response(&game_response, move_number.get_value())
+            {
+                analysis_signal.0.set(analysis_tree);
+                analysis_signal.sync_game_state(game_state);
+            }
         }
     });
 
@@ -77,84 +98,44 @@ pub fn Analysis(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoV
                 },
             )
         }>
-            <Suspense fallback=move || {
-                view! { <div>"Loading analysis..."</div> }
-            }>
-                {move || {
-                    let analysis_signal = game_resource
-                        .with(|gr| {
-                            let analysis_tree = match gr {
-                                Some(Ok(game_response)) if !should_block_analysis(game_response) => {
-                                    AnalysisTree::from_game_response(
-                                            game_response,
-                                            game_state,
-                                            move_number.get_value(),
-                                        )
-                                        .unwrap_or_default()
-                                }
-                                _ => {
-                                    uhp_string
-                                        .get_value()
-                                        .and_then(|uhp| {
-                                            AnalysisTree::from_uhp(game_state, uhp).ok()
-                                        })
-                                        .unwrap_or_else(|| {
-                                            AnalysisTree::new_blank_analysis(game_state, GameType::MLP)
-                                        })
-                                }
-                            };
-                            AnalysisSignal(RwSignal::new(analysis_tree))
-                        });
-                    provide_context(analysis_signal);
-
+            <Show
+                when=vertical
+                fallback=move || {
                     view! {
-                        <Show
-                            when=vertical
-                            fallback=move || {
-                                view! {
-                                    <AnalysisInfo extend_tw_classes="absolute pl-4 pt-2 bg-transparent" />
-                                    <Board />
-                                    <div class="flex flex-col col-span-2 row-span-6 p-1 h-full border-2 border-black select-none dark:border-white">
-                                        <History />
-                                    </div>
-                                }
-                            }
-                        >
-                            <div class="flex flex-col h-[85dvh]">
-                                <div class="flex flex-col flex-grow shrink">
-                                    <div class="flex justify-between h-full max-h-16">
-                                        <Reserve
-                                            alignment=Alignment::SingleRow
-                                            color=Color::White
-                                        />
-                                    </div>
-                                </div>
-                                <AnalysisInfo />
-                                <Board />
-                                <div class="flex flex-col flex-grow shrink">
-                                    <div class="flex justify-between h-full max-h-16">
-                                        <Reserve
-                                            alignment=Alignment::SingleRow
-                                            color=Color::Black
-                                        />
-                                    </div>
-                                </div>
-                            </div>
-                            <History mobile=true />
-                        </Show>
+                        <AnalysisInfo extend_tw_classes="absolute pl-4 pt-2 bg-transparent" />
+                        <Board />
+                        <div class="flex flex-col col-span-2 row-span-6 p-1 h-full border-2 border-black select-none dark:border-white">
+                            <History />
+                        </div>
                     }
-                }}
-            </Suspense>
+                }
+            >
+                <div class="flex flex-col h-[85dvh]">
+                    <div class="flex flex-col flex-grow shrink">
+                        <div class="flex justify-between h-full max-h-16">
+                            <Reserve alignment=Alignment::SingleRow color=Color::White />
+                        </div>
+                    </div>
+                    <AnalysisInfo />
+                    <Board />
+                    <div class="flex flex-col flex-grow shrink">
+                        <div class="flex justify-between h-full max-h-16">
+                            <Reserve alignment=Alignment::SingleRow color=Color::Black />
+                        </div>
+                    </div>
+                </div>
+                <History mobile=true />
+            </Show>
         </div>
     }
 }
 
 #[component]
 fn AnalysisInfo(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
-    let analysis = expect_context::<AnalysisSignal>().0;
+    let analysis = expect_context::<AnalysisStore>();
     let game_state = expect_context::<GameStateStore>();
     let moves = move || {
-        analysis.with(|a| {
+        analysis.0.with(|a| {
             let tree = &a.tree;
             let mut moves = Vec::new();
             let sibling_nodes = a.current_node
@@ -172,17 +153,16 @@ fn AnalysisInfo(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoV
                     piece,
                     position,
                 })) = s.get_value() {
+                let analysis = analysis.clone();
                 moves.push(
                         view! {
                             <div
                                 class="underline cursor-pointer active:scale-95 no-link-style hover:text-pillbug-teal"
                                 on:click=move |_| {
-                                    analysis
-                                        .update(|a| {
-                                            if let Ok(node_id) = s.get_node_id() {
-                                                a.update_node(node_id, Some(game_state));
-                                            }
-                                        })
+                                    if let Ok(node_id) = s.get_node_id() {
+                                        analysis.update_node(node_id);
+                                        analysis.sync_game_state(game_state);
+                                    }
                                 }
                             >
                                 {format!("{turn}. {piece} {position}")}

--- a/apis/src/pages/analysis.rs
+++ b/apis/src/pages/analysis.rs
@@ -12,7 +12,7 @@ use crate::{
     pages::play::CurrentConfirm,
     providers::{
         analysis::{AnalysisSignal, AnalysisTree, TreeNode},
-        game_state::GameStateSignal,
+        game_state::GameStateStore,
         AuthContext,
     },
     responses::GameResponse,
@@ -28,7 +28,7 @@ pub struct ToggleStates(pub RwSignal<HashSet<i32>>);
 
 #[component]
 pub fn Analysis(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let auth_context = expect_context::<AuthContext>();
     let params = use_params_map();
     let queries = use_query_map();
@@ -152,7 +152,7 @@ pub fn Analysis(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoV
 #[component]
 fn AnalysisInfo(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
     let analysis = expect_context::<AnalysisSignal>().0;
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let moves = move || {
         analysis.with(|a| {
             let tree = &a.tree;

--- a/apis/src/pages/analysis.rs
+++ b/apis/src/pages/analysis.rs
@@ -11,21 +11,61 @@ use crate::{
     functions::games::get::get_game_from_nanoid,
     pages::play::CurrentConfirm,
     providers::{
-        analysis::{AnalysisStore, AnalysisTree, TreeNode},
-        game_state::GameStateStore,
+        analysis::{AnalysisStore, AnalysisTree, AnalysisTreeStoreFields, TreeNode},
+        game_state::{GameStateStore, GameStateStoreFields},
         AuthContext,
     },
     responses::GameResponse,
 };
-use hive_lib::{Color, GameStatus, GameType};
-use leptos::prelude::*;
+use hive_lib::{Color, GameError, GameStatus, GameType, History, State};
+use leptos::{either::Either, prelude::*};
 use leptos_router::hooks::{use_params_map, use_query_map};
 use reactive_stores::Store;
 use shared_types::{GameId, TimeMode};
 use std::collections::HashSet;
+use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct ToggleStates(pub RwSignal<HashSet<i32>>);
+
+fn should_block_analysis(user_id: Option<Uuid>, game_response: &GameResponse) -> bool {
+    user_id.is_some_and(|user_id| {
+        game_response.rated
+            && matches!(game_response.game_status, GameStatus::InProgress)
+            && game_response.time_mode == TimeMode::RealTime
+            && (Some(user_id) == Some(game_response.white_player.uid)
+                || Some(user_id) == Some(game_response.black_player.uid))
+    })
+}
+
+fn state_from_uhp(uhp_string: impl Into<String>) -> Result<State, GameError> {
+    let history = match History::from_uhp_str(uhp_string.into()) {
+        Ok(history) => history,
+        Err(GameError::PartialHistory { history, .. }) => history,
+        Err(err) => return Err(err),
+    };
+    State::new_from_history(&history)
+}
+
+fn analysis_tree_from_sources(
+    state_from_uhp: Option<State>,
+    game_response: Option<&GameResponse>,
+    move_number: Option<usize>,
+) -> AnalysisTree {
+    let fallback_game_type = game_response
+        .map(|game_response| game_response.game_type)
+        .unwrap_or(GameType::MLP);
+
+    let analysis_tree = state_from_uhp
+        .map(|state| AnalysisTree::from_loaded_state(&state, move_number))
+        .or_else(|| {
+            game_response
+                .map(|game_response| AnalysisTree::from_game_response(game_response, move_number))
+        })
+        .unwrap_or_else(|| AnalysisTree::new_blank_analysis(fallback_game_type));
+
+    analysis_tree
+}
 
 #[component]
 pub fn Analysis(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
@@ -33,56 +73,28 @@ pub fn Analysis(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoV
     let auth_context = expect_context::<AuthContext>();
     let params = use_params_map();
     let queries = use_query_map();
-    let game_id = Memo::new(move |_| params().get("nanoid").map(|s| GameId(s.to_owned())));
-    let move_number = StoredValue::new(
-        queries
-            .get_untracked()
+    let game_id = Memo::new(move |_| params.get().get("nanoid").map(|s| GameId(s.to_owned())));
+    let query_inputs = Memo::new(move |_| {
+        let q = queries.get();
+        let move_number = q
             .get("move")
             .and_then(|s| s.parse::<usize>().ok())
-            .map(|n| n.saturating_sub(1)),
-    );
-    let uhp_string = StoredValue::new(queries.get_untracked().get("uhp"));
+            .map(|n| n.saturating_sub(1));
+        let uhp_string = q.get("uhp");
+        (move_number, uhp_string)
+    });
+    let vertical = expect_context::<OrientationSignal>().orientation_vertical;
 
     provide_context(ToggleStates(RwSignal::new(HashSet::new())));
     provide_context(CurrentConfirm(Memo::new(move |_| MoveConfirm::Single)));
-    let vertical = expect_context::<OrientationSignal>().orientation_vertical;
-
-    let should_block_analysis = move |game_response: &GameResponse| -> bool {
-        let Some(user_id) = auth_context.user.with(|u| u.as_ref().map(|u| u.id)) else {
-            return false;
-        };
-
-        game_response.rated
-            && matches!(game_response.game_status, GameStatus::InProgress)
-            && game_response.time_mode == TimeMode::RealTime
-            && (Some(user_id) == Some(game_response.white_player.uid)
-                || Some(user_id) == Some(game_response.black_player.uid))
-    };
-
-    let game_resource = OnceResource::new(async move {
-        if let Some(game_id) = game_id.get() {
-            get_game_from_nanoid(game_id).await
-        } else {
-            Err(leptos::prelude::ServerFnError::new("No game ID provided"))
-        }
-    });
-    let analysis_signal = AnalysisStore(Store::new(
-        uhp_string
-            .get_value()
-            .and_then(|uhp| AnalysisTree::from_uhp(game_state, uhp).ok())
-            .unwrap_or_else(|| AnalysisTree::new_blank_analysis(game_state, GameType::MLP)),
-    ));
-    provide_context(analysis_signal.clone());
-    Effect::new(move |_| {
-        if let Some(Ok(game_response)) = game_resource.get() {
-            if should_block_analysis(&game_response) {
-                return;
-            }
-            if let Some(analysis_tree) =
-                AnalysisTree::from_game_response(&game_response, move_number.get_value())
-            {
-                analysis_signal.0.set(analysis_tree);
-                analysis_signal.sync_game_state(game_state);
+    let game_resource = LocalResource::new(move || {
+        let game_id = game_id.get();
+        async move {
+            if let Some(game_id) = game_id {
+                let result = get_game_from_nanoid(game_id.clone()).await;
+                result
+            } else {
+                Err(leptos::prelude::ServerFnError::new("No game ID provided"))
             }
         }
     });
@@ -98,35 +110,96 @@ pub fn Analysis(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoV
                 },
             )
         }>
-            <Show
-                when=vertical
-                fallback=move || {
-                    view! {
-                        <AnalysisInfo extend_tw_classes="absolute pl-4 pt-2 bg-transparent" />
-                        <Board />
-                        <div class="flex flex-col col-span-2 row-span-6 p-1 h-full border-2 border-black select-none dark:border-white">
-                            <History />
-                        </div>
-                    }
-                }
-            >
-                <div class="flex flex-col h-[85dvh]">
-                    <div class="flex flex-col flex-grow shrink">
-                        <div class="flex justify-between h-full max-h-16">
-                            <Reserve alignment=Alignment::SingleRow color=Color::White />
-                        </div>
-                    </div>
-                    <AnalysisInfo />
-                    <Board />
-                    <div class="flex flex-col flex-grow shrink">
-                        <div class="flex justify-between h-full max-h-16">
-                            <Reserve alignment=Alignment::SingleRow color=Color::Black />
-                        </div>
+            <Suspense fallback=move || {
+                view! { <div>"Loading analysis..."</div> }
+            }>
+                {move || {
+                    game_resource
+                        .get()
+                        .map(|result| {
+                            let game_response = result.ok();
+                            let user_id = auth_context.user.with(|u| u.as_ref().map(|u| u.id));
+                            let should_block_analysis = game_response
+                                .as_ref()
+                                .is_some_and(|game_response| {
+                                    should_block_analysis(user_id, game_response)
+                                });
+                            if should_block_analysis {
+                                Either::Left(
+
+                                    view! { <div>"Analysis is unavailable for this game."</div> },
+                                )
+                            } else {
+                                let (move_number, uhp_string) = query_inputs.get();
+                                let uhp_state = uhp_string.and_then(|uhp| state_from_uhp(uhp).ok());
+                                let analysis_tree = analysis_tree_from_sources(
+                                    uhp_state.clone(),
+                                    game_response.as_ref(),
+                                    move_number,
+                                );
+                                let vertical = vertical();
+                                let game_type = analysis_tree.game_type;
+                                let analysis_signal = AnalysisStore(Store::new(analysis_tree));
+                                game_state.view().set(crate::providers::game_state::View::Game);
+                                let mut state = uhp_state
+                                    .or_else(|| {
+                                        game_response
+                                            .as_ref()
+                                            .map(|game_response| game_response.create_state())
+                                    })
+                                    .unwrap_or_else(|| State::new(game_type, false));
+                                state.game_status = GameStatus::InProgress;
+                                if let Some(m) = move_number {
+                                    let n_history_moves = state.history.moves.len();
+                                    if m < n_history_moves {
+                                        state.undo(n_history_moves - m - 1);
+                                    }
+                                }
+                                let history_turn = if state.history.moves.is_empty() {
+                                    None
+                                } else {
+                                    Some(state.history.moves.len())
+                                };
+                                game_state.history_turn().set(history_turn);
+                                game_state.state().set(state);
+                                provide_context(analysis_signal);
+                                Either::Right(view! { <AnalysisContent vertical /> })
+                            }
+                        })
+                }}
+            </Suspense>
+        </div>
+    }
+}
+
+#[component]
+fn AnalysisContent(vertical: bool) -> impl IntoView {
+    if vertical {
+        Either::Left(view! {
+            <div class="flex flex-col h-[85dvh]">
+                <div class="flex flex-col flex-grow shrink">
+                    <div class="flex justify-between h-full max-h-16">
+                        <Reserve alignment=Alignment::SingleRow color=Color::White />
                     </div>
                 </div>
-                <History mobile=true />
-            </Show>
-        </div>
+                <AnalysisInfo />
+                <Board />
+                <div class="flex flex-col flex-grow shrink">
+                    <div class="flex justify-between h-full max-h-16">
+                        <Reserve alignment=Alignment::SingleRow color=Color::Black />
+                    </div>
+                </div>
+            </div>
+            <History mobile=true />
+        })
+    } else {
+        Either::Right(view! {
+            <AnalysisInfo extend_tw_classes="absolute pl-4 pt-2 bg-transparent" />
+            <Board />
+            <div class="flex flex-col col-span-2 row-span-6 p-1 h-full border-2 border-black select-none dark:border-white">
+                <History />
+            </div>
+        })
     }
 }
 
@@ -135,50 +208,51 @@ fn AnalysisInfo(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoV
     let analysis = expect_context::<AnalysisStore>();
     let game_state = expect_context::<GameStateStore>();
     let moves = move || {
-        analysis.0.with(|a| {
-            let tree = &a.tree;
-            let mut moves = Vec::new();
-            let sibling_nodes = a.current_node
-                .as_ref()
-                .and_then(|n| n.get_node_id().ok())
-                .and_then(|node_id| tree.get_sibling_ids(&node_id, false).ok())
-                .map_or(Vec::new(), |s| {
-                    s.iter()
-                        .filter_map(|id| tree.get_node_by_id(id))
-                        .collect::<Vec<_>>()
-                });
-            for s in sibling_nodes {
-                if let Ok(Some(TreeNode {
-                    turn,
-                    piece,
-                    position,
-                })) = s.get_value() {
+        let mut moves = Vec::new();
+        let current_node = analysis.current_node().get();
+        let tree = analysis.tree().get();
+        let sibling_nodes = current_node
+            .as_ref()
+            .and_then(|n| n.get_node_id().ok())
+            .and_then(|node_id| tree.get_sibling_ids(&node_id, false).ok())
+            .map_or(Vec::new(), |s| {
+                s.iter()
+                    .filter_map(|id| tree.get_node_by_id(id))
+                    .collect::<Vec<_>>()
+            });
+
+        for s in sibling_nodes {
+            if let Ok(Some(TreeNode {
+                turn,
+                piece,
+                position,
+            })) = s.get_value()
+            {
                 let analysis = analysis.clone();
                 moves.push(
-                        view! {
-                            <div
-                                class="underline cursor-pointer active:scale-95 no-link-style hover:text-pillbug-teal"
-                                on:click=move |_| {
-                                    if let Ok(node_id) = s.get_node_id() {
-                                        analysis.update_node(node_id);
-                                        analysis.sync_game_state(game_state);
-                                    }
+                    view! {
+                        <div
+                            class="underline cursor-pointer active:scale-95 no-link-style hover:text-pillbug-teal"
+                            on:click=move |_| {
+                                if let Ok(node_id) = s.get_node_id() {
+                                    analysis.update_node(node_id);
+                                    analysis.sync_game_state(game_state);
                                 }
-                            >
-                                {format!("{turn}. {piece} {position}")}
-                            </div>
-                        }
-                    );
-                }
+                            }
+                        >
+                            {format!("{turn}. {piece} {position}")}
+                        </div>
+                    },
+                );
             }
-            moves.collect_view()
-        })
+        }
+        moves
     };
     view! {
         <div class=extend_tw_classes>
             <div class="flex gap-1 items-center">
                 <b>"Other Lines Explored: "</b>
-                {moves}
+                {move || moves}
             </div>
         </div>
     }

--- a/apis/src/pages/play.rs
+++ b/apis/src/pages/play.rs
@@ -20,7 +20,7 @@ use crate::{
     functions::games::get::get_game_from_nanoid,
     providers::{
         config::Config,
-        game_state::{GameStateSignal, View},
+        game_state::{GameStateStore, GameStateStoreFields, View},
         timer::TimerSignal,
         websocket::WebsocketContext,
         ApiRequestsProvider,
@@ -45,7 +45,7 @@ pub struct CurrentConfirm(pub Memo<MoveConfirm>);
 pub fn Play() -> impl IntoView {
     provide_context(TimerSignal::new());
     let timer = expect_context::<TimerSignal>();
-    let mut game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let orientation_signal = expect_context::<OrientationSignal>();
     let auth_context = expect_context::<AuthContext>();
     let config = expect_context::<Config>().0;
@@ -75,7 +75,6 @@ pub fn Play() -> impl IntoView {
         config.with(|cfg| {
             let preferred_confirms = &cfg.confirm_mode;
             game_state
-                .signal
                 .with(|gs| gs.get_game_speed())
                 .and_then(|game_speed| preferred_confirms.get(&game_speed).cloned())
                 .unwrap_or_default()
@@ -83,7 +82,8 @@ pub fn Play() -> impl IntoView {
     });
     provide_context(CurrentConfirm(current_confirm));
     let user = auth_context.user;
-    let white_and_black_ids = create_read_slice(game_state.signal, |gs| (gs.white_id, gs.black_id));
+    let white_and_black_ids =
+        Signal::derive(move || (game_state.white_id().get(), game_state.black_id().get()));
     let user_is_player = Signal::derive(move || {
         user.with(|a| {
             if let Some(user) = a {
@@ -113,8 +113,8 @@ pub fn Play() -> impl IntoView {
         }
     };
 
-    let show_board = create_read_slice(game_state.signal, |gs| {
-        !gs.game_response.as_ref().is_some_and(|gr| {
+    let show_board = Signal::derive(move || {
+        !game_state.game_response().get().as_ref().is_some_and(|gr| {
             gr.game_start == GameStart::Ready && matches!(gr.game_status, GameStatus::NotStarted)
         })
     });
@@ -151,11 +151,9 @@ pub fn Play() -> impl IntoView {
                     }
                     let url_number = move_number.get_untracked();
                     if url_number.is_some_and(|v| {
-                        game_state
-                            .signal
-                            .with_untracked(|gs| v < gs.state.turn.saturating_sub(1))
+                        game_state.with_untracked(|gs| v < gs.state.turn.saturating_sub(1))
                     }) {
-                        game_state.signal.update(|s| {
+                        game_state.update(|s| {
                             s.history_turn = url_number;
                             s.view = View::History;
                         });
@@ -180,8 +178,8 @@ pub fn Play() -> impl IntoView {
                             game_state.clear_gc();
                             game_state.set_game_response(gar.game.clone());
                             sounds.play_sound(SoundType::Turn);
-                            let (pos, reserve_pos, history_moves, active) =
-                                game_state.signal.with_untracked(|gs| {
+                            let (pos, reserve_pos, history_moves, active) = game_state
+                                .with_untracked(|gs| {
                                     (
                                         gs.move_info.current_position,
                                         gs.move_info.reserve_position,
@@ -232,7 +230,7 @@ pub fn Play() -> impl IntoView {
                                 }
                                 GameControl::TakebackAccept(_) => {
                                     timer.update_from(&gar.game);
-                                    reset_game_state_for_takeback(&gar.game, &mut game_state);
+                                    reset_game_state_for_takeback(&gar.game, &game_state);
                                 }
                                 GameControl::TakebackRequest(_)
                                 | GameControl::DrawOffer(_)
@@ -360,11 +358,11 @@ fn VerticalLayout(
     white_and_black_ids: Signal<(Option<Uuid>, Option<Uuid>)>,
     game_id: Memo<GameId>,
 ) -> impl IntoView {
-    let game_state = expect_context::<GameStateSignal>();
+    let game_state = expect_context::<GameStateStore>();
     let controls_signal = expect_context::<ControlsSignal>();
     let vertical = true;
     let go_to_game = Callback::new(move |()| {
-        if game_state.signal.with_untracked(|gs| gs.is_last_turn()) {
+        if game_state.with_untracked(|gs| gs.is_last_turn()) {
             game_state.view_game();
         }
     });

--- a/apis/src/providers/analysis.rs
+++ b/apis/src/providers/analysis.rs
@@ -3,8 +3,8 @@ use crate::{
     responses::GameResponse,
 };
 use bimap::BiMap;
-use hive_lib::{GameError, GameType, History, State};
-use leptos::{logging, prelude::*};
+use hive_lib::{GameType, History, State};
+use leptos::prelude::*;
 use reactive_stores::Store;
 use serde::{Deserialize, Serialize};
 use std::{ops::Deref, vec};
@@ -36,9 +36,10 @@ impl AnalysisStore {
 
     pub fn sync_game_state(&self, game: GameStateStore) -> Option<()> {
         let mut success = true;
-        let history_turn = game.history_turn().get().unwrap_or_default();
-        if let Some(current_id) = self.current_node().get().and_then(|n| n.get_node_id().ok()) {
+        let current_node_id = self.current_node().get().and_then(|n| n.get_node_id().ok());
+        if let Some(current_id) = current_node_id {
             if let Some(path_pos) = self.full_path().get().iter().position(|n| n == &current_id) {
+                let history_turn = game.history_turn().get().unwrap_or_default();
                 let path_pos = path_pos + 1;
                 if path_pos <= history_turn {
                     game.undo_n_moves(history_turn - path_pos);
@@ -99,14 +100,19 @@ pub struct AnalysisTree {
 }
 
 impl AnalysisTree {
-    pub fn new_blank_analysis(game_state: GameStateStore, game_type: GameType) -> Self {
+    fn update_node_if_in_range(&mut self, move_number: Option<usize>) {
+        let Some(move_idx) = move_number else {
+            return;
+        };
+        let node_id = move_idx as i32;
+        if self.tree.get_node_by_id(&node_id).is_some() {
+            self.update_node(node_id);
+        }
+    }
+
+    pub fn new_blank_analysis(game_type: GameType) -> Self {
         let tree = Tree::new(Some("analysis"));
         let hashes = BiMap::new();
-        game_state.update(|gs| {
-            *gs = GameState::new_with_game_type(game_type);
-            gs.view = game_state::View::Game;
-        });
-
         Self {
             current_node: None,
             tree,
@@ -116,11 +122,11 @@ impl AnalysisTree {
         }
     }
 
-    pub fn from_loaded_state(game_state: GameStateStore, state: &State) -> Self {
+    pub fn from_loaded_state(state: &State, move_number: Option<usize>) -> Self {
         let mut tree = Tree::new(Some("analysis"));
         let mut hashes = BiMap::new();
         let mut previous = None;
-
+        let mut full_path = Vec::new();
         for (i, (piece, position)) in state.history.moves.iter().enumerate() {
             let new_node = Node::new(
                 i as i32,
@@ -133,84 +139,27 @@ impl AnalysisTree {
             if let Ok(new_id) = new_node.get_node_id() {
                 let hash = state.history.hashes[i];
                 tree.add_node(new_node, previous.as_ref()).ok();
+                full_path.push(new_id);
                 hashes.insert(hash, new_id);
                 previous = Some(new_id);
             }
         }
 
-        let current_node = previous.and_then(|p| tree.get_node_by_id(&p));
-
-        game_state.update(|gs| {
-            gs.view = game_state::View::Game;
-        });
-
-        Self {
-            current_node,
-            tree,
-            hashes,
-            game_type: state.game_type,
-            full_path: vec![],
-        }
-    }
-
-    pub fn from_game_response(
-        game_response: &GameResponse,
-        move_number: Option<usize>,
-    ) -> Option<Self> {
-        let state = game_response.create_state();
-        let mut tree = Tree::new(Some("analysis"));
-        let mut hashes = BiMap::new();
-        let mut previous = None;
-
-        for (i, (piece, position)) in state.history.moves.iter().enumerate() {
-            let new_node = Node::new(
-                i as i32,
-                Some(TreeNode {
-                    turn: i + 1,
-                    piece: piece.to_string(),
-                    position: position.to_string(),
-                }),
-            );
-            if let Ok(new_id) = new_node.get_node_id() {
-                let hash = state.history.hashes[i];
-                tree.add_node(new_node, previous.as_ref()).ok()?;
-                hashes.insert(hash, new_id);
-                previous = Some(new_id);
-            }
-        }
         let current_node = previous.and_then(|p| tree.get_node_by_id(&p));
         let mut analysis_tree = Self {
             current_node,
             tree,
             hashes,
             game_type: state.game_type,
-            full_path: vec![],
+            full_path,
         };
-
-        let move_count = state.history.moves.len();
-        let target_move_id = move_number.unwrap_or(move_count.saturating_sub(1)) as i32;
-        analysis_tree.update_node(target_move_id);
-        Some(analysis_tree)
+        analysis_tree.update_node_if_in_range(move_number);
+        analysis_tree
     }
 
-    pub fn from_uhp(
-        game_state: GameStateStore,
-        uhp_string: impl Into<String>,
-    ) -> Result<Self, GameError> {
-        let normalized_uhp = normalize_uhp_metadata(uhp_string);
-        let history = match History::from_uhp_str(normalized_uhp) {
-            Ok(history) => history,
-            Err(GameError::PartialHistory { history, .. }) => history,
-            Err(err) => return Err(err),
-        };
-        let state = State::new_from_history(&history)?;
-
-        game_state.update(|gs| {
-            gs.state = state.clone();
-            gs.view = game_state::View::Game;
-        });
-
-        Ok(Self::from_loaded_state(game_state, &state))
+    pub fn from_game_response(game_response: &GameResponse, move_number: Option<usize>) -> Self {
+        let state = game_response.create_state();
+        Self::from_loaded_state(&state, move_number)
     }
 
     pub fn update_node(&mut self, node_id: i32) {
@@ -248,7 +197,7 @@ impl AnalysisTree {
         self.full_path = full_path;
     }
 
-    fn state_and_turn_for_node(&self) -> Option<(State, Option<usize>)> {
+    pub fn state_and_turn_for_node(&self) -> Option<(State, Option<usize>)> {
         let node_id = self
             .current_node
             .as_ref()
@@ -353,7 +302,6 @@ impl AnalysisTree {
             self.full_path.clear();
         }
         self.full_path.push(new_id);
-        logging::log!("{:?}", self.full_path);
     }
 
     pub fn reset(&mut self, game_state: GameStateStore) {
@@ -365,24 +313,5 @@ impl AnalysisTree {
             *gs = GameState::new_with_game_type(self.game_type);
             gs.view = game_state::View::Game;
         });
-    }
-}
-
-fn normalize_uhp_metadata(uhp_string: impl Into<String>) -> String {
-    let input = uhp_string.into();
-    let mut split = input.splitn(2, ';');
-    let header = split.next().unwrap_or_default();
-    let rest = split.next();
-
-    // Query parameters decode '+' into ' ', so restore it for the game type metadata token.
-    if header.starts_with("Base") && header.contains(' ') && !header.contains('+') {
-        let normalized_header = header.replace(' ', "+");
-        match rest {
-            Some("") => normalized_header,
-            Some(rest) => format!("{normalized_header};{rest}"),
-            None => normalized_header,
-        }
-    } else {
-        input
     }
 }

--- a/apis/src/providers/analysis.rs
+++ b/apis/src/providers/analysis.rs
@@ -1,5 +1,5 @@
 use crate::{
-    providers::game_state::{GameState, GameStateSignal},
+    providers::game_state::{GameState, GameStateStore},
     responses::GameResponse,
 };
 use bimap::BiMap;
@@ -28,10 +28,10 @@ pub struct AnalysisTree {
 }
 
 impl AnalysisTree {
-    pub fn new_blank_analysis(game_state: GameStateSignal, game_type: GameType) -> Self {
+    pub fn new_blank_analysis(game_state: GameStateStore, game_type: GameType) -> Self {
         let tree = Tree::new(Some("analysis"));
         let hashes = BiMap::new();
-        game_state.signal.update(|gs| {
+        game_state.update(|gs| {
             *gs = GameState::new_with_game_type(game_type);
             gs.view = game_state::View::Game;
         });
@@ -44,7 +44,7 @@ impl AnalysisTree {
         }
     }
 
-    pub fn from_loaded_state(game_state: GameStateSignal, state: &State) -> Self {
+    pub fn from_loaded_state(game_state: GameStateStore, state: &State) -> Self {
         let mut tree = Tree::new(Some("analysis"));
         let mut hashes = BiMap::new();
         let mut previous = None;
@@ -68,7 +68,7 @@ impl AnalysisTree {
 
         let current_node = previous.and_then(|p| tree.get_node_by_id(&p));
 
-        game_state.signal.update(|gs| {
+        game_state.update(|gs| {
             gs.view = game_state::View::Game;
         });
 
@@ -82,7 +82,7 @@ impl AnalysisTree {
 
     pub fn from_game_response(
         game_response: &GameResponse,
-        game_state: GameStateSignal,
+        game_state: GameStateStore,
         move_number: Option<usize>,
     ) -> Option<Self> {
         let state = game_response.create_state();
@@ -116,7 +116,7 @@ impl AnalysisTree {
 
         let move_count = state.history.moves.len();
 
-        game_state.signal.update(|gs| {
+        game_state.update(|gs| {
             gs.view = game_state::View::Game;
             gs.game_id = Some(game_response.game_id.clone());
             gs.state = state;
@@ -131,7 +131,7 @@ impl AnalysisTree {
     }
 
     pub fn from_uhp(
-        game_state: GameStateSignal,
+        game_state: GameStateStore,
         uhp_string: impl Into<String>,
     ) -> Result<Self, GameError> {
         let normalized_uhp = normalize_uhp_metadata(uhp_string);
@@ -142,7 +142,7 @@ impl AnalysisTree {
         };
         let state = State::new_from_history(&history)?;
 
-        game_state.signal.update(|gs| {
+        game_state.update(|gs| {
             gs.state = state.clone();
             gs.view = game_state::View::Game;
         });
@@ -150,7 +150,7 @@ impl AnalysisTree {
         Ok(Self::from_loaded_state(game_state, &state))
     }
 
-    pub fn update_node(&mut self, node_id: i32, game: Option<GameStateSignal>) -> Option<()> {
+    pub fn update_node(&mut self, node_id: i32, game: Option<GameStateStore>) -> Option<()> {
         let moves = self
             .tree
             .get_ancestor_ids(&node_id)
@@ -183,7 +183,7 @@ impl AnalysisTree {
             .map(|v| v.turn);
 
         if let Some(g) = game {
-            g.signal.update(|gs| {
+            g.update(|gs| {
                 gs.state = state;
                 gs.history_turn = history_turn;
                 gs.move_info.reset();
@@ -239,11 +239,11 @@ impl AnalysisTree {
         self.current_node = self.tree.get_node_by_id(&new_id);
     }
 
-    pub fn reset(&mut self, game_state: GameStateSignal) {
+    pub fn reset(&mut self, game_state: GameStateStore) {
         self.current_node = None;
         self.tree = Tree::new(Some("analysis"));
         self.hashes.clear();
-        game_state.signal.update(|gs| {
+        game_state.update(|gs| {
             *gs = GameState::new_with_game_type(self.game_type);
             gs.view = game_state::View::Game;
         });

--- a/apis/src/providers/analysis.rs
+++ b/apis/src/providers/analysis.rs
@@ -1,12 +1,13 @@
 use crate::{
-    providers::game_state::{GameState, GameStateStore},
+    providers::game_state::{GameState, GameStateStore, GameStateStoreFields},
     responses::GameResponse,
 };
 use bimap::BiMap;
 use hive_lib::{GameError, GameType, History, State};
-use leptos::prelude::*;
+use leptos::{logging, prelude::*};
+use reactive_stores::Store;
 use serde::{Deserialize, Serialize};
-use std::vec;
+use std::{ops::Deref, vec};
 use tree_ds::prelude::{Node, Tree};
 
 use super::game_state;
@@ -16,15 +17,85 @@ pub struct TreeNode {
     pub piece: String,
     pub position: String,
 }
-#[derive(Clone)]
-pub struct AnalysisSignal(pub RwSignal<AnalysisTree>);
+#[derive(Clone, Copy)]
+pub struct AnalysisStore(pub Store<AnalysisTree>);
 
-#[derive(Clone, Default, Serialize, Deserialize)]
+impl Deref for AnalysisStore {
+    type Target = Store<AnalysisTree>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AnalysisStore {
+    pub fn update_node(&self, node_id: i32) {
+        self.current_node()
+            .set(self.tree().get().get_node_by_id(&node_id));
+    }
+
+    pub fn sync_game_state(&self, game: GameStateStore) -> Option<()> {
+        let mut success = true;
+        let history_turn = game.history_turn().get().unwrap_or_default();
+        if let Some(current_id) = self.current_node().get().and_then(|n| n.get_node_id().ok()) {
+            if let Some(path_pos) = self.full_path().get().iter().position(|n| n == &current_id) {
+                let path_pos = path_pos + 1;
+                if path_pos <= history_turn {
+                    game.undo_n_moves(history_turn - path_pos);
+                } else {
+                    let moves_to_play = self
+                        .full_path()
+                        .get()
+                        .iter()
+                        .skip(history_turn)
+                        .take(path_pos - history_turn)
+                        .filter_map(|node_id| {
+                            self.tree()
+                                .get()
+                                .get_node_by_id(node_id)
+                                .and_then(|node| node.get_value().ok())
+                                .flatten()
+                                .map(|tree_node| (tree_node.piece, tree_node.position))
+                        })
+                        .collect::<Vec<_>>();
+                    game.state().update(|state| {
+                        for (piece, position) in moves_to_play {
+                            if let Err(e) = state.play_turn_from_history(&piece, &position) {
+                                leptos::logging::log!(
+                                    "Could not play history turn: {} {} {}",
+                                    piece,
+                                    position,
+                                    e
+                                );
+                                break;
+                            }
+                        }
+                    });
+                    game.history_turn().set(Some(path_pos));
+                }
+            } else if let Some((state, history_turn)) = self.with(|a| a.state_and_turn_for_node()) {
+                game.state().set(state);
+                game.history_turn().set(history_turn);
+                game.move_info().update(|m| m.reset());
+                self.update(|a| a.recompute_full_path_from_current());
+            } else {
+                success = false;
+            }
+        } else {
+            game.reset();
+        }
+        success.then_some(())
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, Store)]
 pub struct AnalysisTree {
     pub current_node: Option<Node<i32, TreeNode>>,
     pub tree: Tree<i32, TreeNode>,
     pub hashes: BiMap<u64, i32>,
     pub game_type: GameType,
+    #[serde(skip)]
+    pub full_path: Vec<i32>,
 }
 
 impl AnalysisTree {
@@ -41,6 +112,7 @@ impl AnalysisTree {
             tree,
             hashes,
             game_type,
+            full_path: vec![],
         }
     }
 
@@ -77,12 +149,12 @@ impl AnalysisTree {
             tree,
             hashes,
             game_type: state.game_type,
+            full_path: vec![],
         }
     }
 
     pub fn from_game_response(
         game_response: &GameResponse,
-        game_state: GameStateStore,
         move_number: Option<usize>,
     ) -> Option<Self> {
         let state = game_response.create_state();
@@ -112,21 +184,12 @@ impl AnalysisTree {
             tree,
             hashes,
             game_type: state.game_type,
+            full_path: vec![],
         };
 
         let move_count = state.history.moves.len();
-
-        game_state.update(|gs| {
-            gs.view = game_state::View::Game;
-            gs.game_id = Some(game_response.game_id.clone());
-            gs.state = state;
-            gs.game_response = Some(game_response.clone());
-            gs.black_id = Some(game_response.black_player.uid);
-            gs.white_id = Some(game_response.white_player.uid);
-        });
-
         let target_move_id = move_number.unwrap_or(move_count.saturating_sub(1)) as i32;
-        analysis_tree.update_node(target_move_id, Some(game_state));
+        analysis_tree.update_node(target_move_id);
         Some(analysis_tree)
     }
 
@@ -150,7 +213,46 @@ impl AnalysisTree {
         Ok(Self::from_loaded_state(game_state, &state))
     }
 
-    pub fn update_node(&mut self, node_id: i32, game: Option<GameStateStore>) -> Option<()> {
+    pub fn update_node(&mut self, node_id: i32) {
+        self.current_node = self.tree.get_node_by_id(&node_id);
+    }
+
+    pub fn recompute_full_path_from_current(&mut self) {
+        let Some(current_id) = self
+            .current_node
+            .as_ref()
+            .and_then(|n| n.get_node_id().ok())
+        else {
+            self.full_path.clear();
+            return;
+        };
+
+        let mut full_path = self
+            .tree
+            .get_ancestor_ids(&current_id)
+            .ok()
+            .map(|ids| ids.into_iter().rev().collect::<Vec<_>>())
+            .unwrap_or_default();
+        full_path.push(current_id);
+
+        let mut cursor = current_id;
+        while let Some(next_id) = self
+            .tree
+            .get_node_by_id(&cursor)
+            .and_then(|node| node.get_children_ids().ok())
+            .and_then(|children| children.first().copied())
+        {
+            full_path.push(next_id);
+            cursor = next_id;
+        }
+        self.full_path = full_path;
+    }
+
+    fn state_and_turn_for_node(&self) -> Option<(State, Option<usize>)> {
+        let node_id = self
+            .current_node
+            .as_ref()
+            .and_then(|n| n.get_node_id().ok())?;
         let moves = self
             .tree
             .get_ancestor_ids(&node_id)
@@ -172,28 +274,22 @@ impl AnalysisTree {
             ..History::new()
         })
         .ok()?;
-
-        self.current_node = self.tree.get_node_by_id(&node_id);
-
         let history_turn = self
-            .current_node
+            .tree
+            .get_node_by_id(&node_id)
             .as_ref()
             .and_then(|n| n.get_value().ok())
             .flatten()
             .map(|v| v.turn);
-
-        if let Some(g) = game {
-            g.update(|gs| {
-                gs.state = state;
-                gs.history_turn = history_turn;
-                gs.move_info.reset();
-            })
-        }
-        Some(())
+        Some((state, history_turn))
     }
 
     pub fn add_node(&mut self, last_move: (String, String), hash: u64) {
         let (piece, position) = last_move;
+        let previous_node_id = self
+            .current_node
+            .as_ref()
+            .and_then(|n| n.get_node_id().ok());
         let turn = self
             .current_node
             .as_ref()
@@ -206,11 +302,24 @@ impl AnalysisTree {
             .and_then(|node_id| self.tree.get_node_by_id(node_id))
             .and_then(
                 |node| match (node.get_value().ok().flatten(), node.get_node_id().ok()) {
-                    (Some(v), Some(node_id)) if v.turn == turn => self.update_node(node_id, None),
+                    (Some(v), Some(node_id)) if v.turn == turn => Some(node_id),
                     _ => None,
                 },
             );
-        if valid_trasposition.is_some() {
+        if let Some(node_id) = valid_trasposition {
+            if let Some(previous_node_id) = previous_node_id {
+                while self
+                    .full_path
+                    .last()
+                    .is_some_and(|id| *id != previous_node_id)
+                {
+                    self.full_path.pop();
+                }
+            } else {
+                self.full_path.clear();
+            }
+            self.full_path.push(node_id);
+            self.current_node = self.tree.get_node_by_id(&node_id);
             return;
         }
         let mut new_id = self.tree.get_nodes().len() as i32;
@@ -229,20 +338,29 @@ impl AnalysisTree {
             .current_node
             .as_ref()
             .and_then(|n| n.get_node_id().ok());
-
-        if let Some(parent_id) = parent_id {
-            let _ = self.tree.add_node(new_node, Some(&parent_id));
-        } else {
-            let _ = self.tree.add_node(new_node, None);
-        }
+        let _ = self.tree.add_node(new_node, parent_id.as_ref());
         self.hashes.insert(hash, new_id);
         self.current_node = self.tree.get_node_by_id(&new_id);
+        if let Some(previous_node_id) = previous_node_id {
+            while self
+                .full_path
+                .last()
+                .is_some_and(|id| *id != previous_node_id)
+            {
+                self.full_path.pop();
+            }
+        } else {
+            self.full_path.clear();
+        }
+        self.full_path.push(new_id);
+        logging::log!("{:?}", self.full_path);
     }
 
     pub fn reset(&mut self, game_state: GameStateStore) {
         self.current_node = None;
         self.tree = Tree::new(Some("analysis"));
         self.hashes.clear();
+        self.full_path.clear();
         game_state.update(|gs| {
             *gs = GameState::new_with_game_type(self.game_type);
             gs.view = game_state::View::Game;

--- a/apis/src/providers/game_state.rs
+++ b/apis/src/providers/game_state.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{ops::Deref, str::FromStr};
 
 use crate::{
     common::{MoveInfo, PieceType},
@@ -6,6 +6,7 @@ use crate::{
 };
 use hive_lib::{Color, GameControl, GameStatus, GameType, Piece, Position, State, Turn};
 use leptos::{logging::log, prelude::*};
+use reactive_stores::Store;
 use shared_types::{GameId, GameSpeed, Takeback};
 use uuid::Uuid;
 
@@ -16,59 +17,67 @@ use super::{
     ApiRequestsProvider,
 };
 
-#[derive(Clone, Debug, Copy)]
-pub struct GameStateSignal {
-    pub signal: RwSignal<GameState>,
-}
+#[derive(Clone, Copy)]
+pub struct GameStateStore(pub Store<GameState>);
 
-impl Default for GameStateSignal {
-    fn default() -> Self {
-        Self::new()
+impl Deref for GameStateStore {
+    type Target = Store<GameState>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
-impl GameStateSignal {
-    pub fn new() -> Self {
-        Self {
-            signal: RwSignal::new(GameState::new()),
-        }
+impl GameStateStore {
+    pub fn takeback_allowed(&self) -> bool {
+        let color_allowed = |color: &Color, game_response: &GameResponse| {
+            let rated = game_response.rated;
+            let takeback = match color {
+                Color::Black => &game_response.black_player.takeback,
+                Color::White => &game_response.white_player.takeback,
+            };
+            takeback == &Takeback::Always || takeback == &Takeback::CasualOnly && !rated
+        };
+        self.game_response()
+            .get()
+            .as_ref()
+            .is_some_and(|game_response| {
+                color_allowed(&Color::Black, game_response)
+                    && color_allowed(&Color::White, game_response)
+            })
     }
 
-    pub fn full_reset(&mut self) {
+    pub fn full_reset(&self) {
         let state = State::new(GameType::MLP, false);
-        self.signal.update(|s| {
-            s.game_id = None;
-            s.state = state;
-            s.black_id = None;
-            s.white_id = None;
-            s.move_info.reset();
-            s.history_turn = None;
-            s.view = View::Game;
-            s.game_control_pending = None;
-        })
+        self.game_id().set(None);
+        self.state().set(state);
+        self.black_id().set(None);
+        self.white_id().set(None);
+        self.move_info().update(|move_info| move_info.reset());
+        self.history_turn().set(None);
+        self.view().set(View::Game);
+        self.game_control_pending().set(None);
     }
 
-    // No longer access the whole signal when getting user_color
     pub fn user_color_as_signal(&self, user_id: Signal<Option<Uuid>>) -> Signal<Option<Color>> {
-        create_read_slice(self.signal, move |gamestate| {
-            match (gamestate.white_id, gamestate.black_id) {
-                (Some(w), Some(b)) => {
-                    let current_user_id = user_id();
-                    if current_user_id == Some(b) {
-                        Some(Color::Black)
-                    } else if current_user_id == Some(w) {
-                        Some(Color::White)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
+        let white_id = self.white_id();
+        let black_id = self.black_id();
+        Signal::derive(move || {
+            let current_user_id = user_id();
+            let white = white_id.get();
+            let black = black_id.get();
+            if current_user_id == black {
+                Some(Color::Black)
+            } else if current_user_id == white {
+                Some(Color::White)
+            } else {
+                None
             }
         })
     }
 
-    pub fn undo_move(&mut self) {
-        self.signal.update(|s| {
+    pub fn undo_move(&self) {
+        self.0.update(|s| {
             if let Some(turn) = s.history_turn {
                 s.state.undo();
                 if turn > 0 {
@@ -81,26 +90,22 @@ impl GameStateSignal {
     }
 
     pub fn set_game_status(&self, status: GameStatus) {
-        self.signal.update(|s| {
-            s.state.game_status = status;
+        self.state().update(|state| {
+            state.game_status = status;
         })
     }
 
     pub fn set_pending_gc(&self, gc: GameControl) {
-        self.signal.update(|s| {
-            s.game_control_pending = Some(gc);
-        })
+        self.game_control_pending().set(Some(gc))
     }
 
     pub fn clear_gc(&self) {
-        self.signal.update(|s| {
-            s.game_control_pending = None;
-        })
+        self.game_control_pending().set(None)
     }
 
     pub fn send_game_control(&self, game_control: GameControl, user: Uuid) {
         let api = expect_context::<ApiRequestsProvider>().0;
-        self.signal.with_untracked(|gs| {
+        self.0.with_untracked(|gs| {
             if let Some(color) = gs.user_color(user) {
                 if color != game_control.color() {
                     log!("This is a bug, you should only send GCs of your own color, user id color is {color} and gc color is {}", game_control.color());
@@ -113,66 +118,66 @@ impl GameStateSignal {
         })
     }
 
-    pub fn set_state(&mut self, state: State, black_id: Uuid, white_id: Uuid) {
+    pub fn set_state(&self, state: State, black_id: Uuid, white_id: Uuid) {
         self.reset();
         let turn = if state.turn != 0 {
             Some(state.turn - 1)
         } else {
             None
         };
-        self.signal.update(|s| {
-            s.history_turn = turn;
-            s.state = state;
-            s.black_id = Some(black_id);
-            s.white_id = Some(white_id);
+        self.history_turn().set(turn);
+        self.state().set(state);
+        self.black_id().set(Some(black_id));
+        self.white_id().set(Some(white_id));
+    }
+
+    pub fn set_game_id(&self, game_id: GameId) {
+        self.game_id().set(Some(game_id))
+    }
+
+    pub fn play_turn(&self, piece: Piece, position: Position) {
+        self.state().update(|state| {
+            if let Err(e) = state.play_turn_from_position(piece, position) {
+                log!("Could not play turn: {} {} {}", piece, position, e);
+            }
         })
     }
 
-    pub fn set_game_id(&mut self, game_id: GameId) {
-        self.signal.update_untracked(|s| s.game_id = Some(game_id))
+    pub fn reset(&self) {
+        self.move_info().update(|move_info| move_info.reset())
     }
 
-    pub fn play_turn(&mut self, piece: Piece, position: Position) {
-        self.signal.update(|s| {
-            s.play_turn(piece, position);
-        })
-    }
-
-    pub fn reset(&mut self) {
-        self.signal.update(|s| s.move_info.reset())
-    }
-
-    pub fn move_active(&mut self, analysis: Option<AnalysisSignal>, api: ApiRequests) {
-        self.signal.update(|s| s.move_active(analysis, api))
+    pub fn move_active(&self, analysis: Option<AnalysisSignal>, api: ApiRequests) {
+        self.0.update(|s| s.move_active(analysis, api))
     }
 
     pub fn is_move_allowed(&self, in_analysis: bool) -> bool {
-        self.signal
-            .with_untracked(|gs| gs.is_move_allowed(in_analysis))
+        self.0.with_untracked(|gs| gs.is_move_allowed(in_analysis))
     }
 
-    pub fn show_moves(&mut self, piece: Piece, position: Position) {
-        self.signal.update(|s| s.show_moves(piece, position))
+    pub fn show_moves(&self, piece: Piece, position: Position) {
+        self.0.update(|s| s.show_moves(piece, position))
     }
 
-    pub fn show_spawns(&mut self, piece: Piece, position: Position) {
-        self.signal.update(|s| s.show_spawns(piece, position))
+    pub fn show_spawns(&self, piece: Piece, position: Position) {
+        self.0.update(|s| s.show_spawns(piece, position))
     }
 
-    pub fn set_target(&mut self, position: Position) {
-        self.signal.update(|s| s.set_target(position))
+    pub fn set_target(&self, position: Position) {
+        self.move_info()
+            .update(|move_info| move_info.target_position = Some(position))
     }
 
     pub fn show_history_turn(&self, turn: usize) {
-        self.signal.update(|s| s.show_history_turn(turn))
+        self.history_turn().set(Some(turn))
     }
 
-    pub fn first_history_turn(&mut self) {
-        self.signal.update(|s| s.first_history_turn())
+    pub fn first_history_turn(&self) {
+        self.0.update(|s| s.first_history_turn())
     }
 
-    pub fn next_history_turn(&mut self) {
-        self.signal.update(|s| {
+    pub fn next_history_turn(&self) {
+        self.0.update(|s| {
             s.next_history_turn();
             if let Some(turn) = s.history_turn {
                 if s.state.history.move_is_pass(turn) {
@@ -182,8 +187,8 @@ impl GameStateSignal {
         });
     }
 
-    pub fn previous_history_turn(&mut self) {
-        self.signal.update(|s| {
+    pub fn previous_history_turn(&self) {
+        self.0.update(|s| {
             s.previous_history_turn();
             if let Some(turn) = s.history_turn {
                 if s.state.history.move_is_pass(turn) {
@@ -194,47 +199,51 @@ impl GameStateSignal {
     }
 
     pub fn view_game(&self) {
-        self.signal.update(|s| s.view_game())
+        self.0.update(|s| s.view_game())
     }
 
-    pub fn view_history(&mut self) {
-        self.signal.update(|s| s.view_history())
+    pub fn view_history(&self) {
+        self.view().set(View::History)
     }
 
-    pub fn set_game_response(&mut self, game_response: GameResponse) {
-        self.signal
-            .update(|s| s.game_response = Some(game_response));
+    pub fn set_game_response(&self, game_response: GameResponse) {
+        self.game_response().set(Some(game_response));
     }
 
     pub fn is_finished(&self) -> Memo<bool> {
-        let game_status_finished = create_read_slice(self.signal, |game_state| {
-            matches!(
-                game_state.state.game_status,
-                GameStatus::Finished(_) | GameStatus::Adjudicated
-            )
+        let game_state = self.0;
+        let game_status_finished = Signal::derive(move || {
+            game_state.with(|gs| {
+                matches!(
+                    gs.state.game_status,
+                    GameStatus::Finished(_) | GameStatus::Adjudicated
+                )
+            })
         });
-        let game_response_finished = create_read_slice(self.signal, |game_state| {
-            game_state
-                .game_response
-                .as_ref()
-                .is_some_and(|gr| gr.finished)
+        let game_state = self.0;
+        let game_response_finished = Signal::derive(move || {
+            game_state.with(|gs| gs.game_response.as_ref().is_some_and(|gr| gr.finished))
         });
         Memo::new(move |_| game_status_finished() || game_response_finished())
     }
 
     pub fn is_last_turn_as_signal(&self) -> Signal<bool> {
-        create_read_slice(self.signal, |gs| {
-            if gs.state.turn == 0 {
-                true
-            } else {
-                gs.history_turn == Some(gs.state.turn - 1)
-            }
+        let game_state = self.0;
+        Signal::derive(move || {
+            game_state.with(|gs| {
+                if gs.state.turn == 0 {
+                    true
+                } else {
+                    gs.history_turn == Some(gs.state.turn - 1)
+                }
+            })
         })
     }
 
     pub fn is_first_turn_as_signal(&self) -> Signal<bool> {
-        create_read_slice(self.signal, |gs| {
-            gs.history_turn.is_none() || gs.history_turn == Some(0)
+        let game_state = self.0;
+        Signal::derive(move || {
+            game_state.with(|gs| gs.history_turn.is_none() || gs.history_turn == Some(0))
         })
     }
 }
@@ -245,7 +254,7 @@ pub enum View {
     Game,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Store)]
 pub struct GameState {
     // game_id is the nanoid of the game
     pub game_id: Option<GameId>,
@@ -463,23 +472,5 @@ impl GameState {
 
     pub fn get_game_speed(&self) -> Option<GameSpeed> {
         self.game_response.as_ref().map(|gr| gr.speed)
-    }
-
-    pub fn takeback_allowed(&self) -> bool {
-        let color_allowed = |color: &Color, game_response: &GameResponse| {
-            let rated = game_response.rated;
-            let takeback = match color {
-                Color::Black => &game_response.black_player.takeback,
-                Color::White => &game_response.white_player.takeback,
-            };
-            takeback == &Takeback::Always || takeback == &Takeback::CasualOnly && !rated
-        };
-        if let Some(game_response) = self.game_response.as_ref() {
-            let white = color_allowed(&Color::Black, game_response);
-            let black = color_allowed(&Color::White, game_response);
-            white && black
-        } else {
-            false
-        }
     }
 }

--- a/apis/src/providers/game_state.rs
+++ b/apis/src/providers/game_state.rs
@@ -11,7 +11,7 @@ use shared_types::{GameId, GameSpeed, Takeback};
 use uuid::Uuid;
 
 use super::{
-    analysis::AnalysisSignal,
+    analysis::AnalysisStore,
     api_requests::ApiRequests,
     auth_context::AuthContext,
     ApiRequestsProvider,
@@ -75,20 +75,16 @@ impl GameStateStore {
             }
         })
     }
-
-    pub fn undo_move(&self) {
-        self.0.update(|s| {
-            if let Some(turn) = s.history_turn {
-                s.state.undo();
-                if turn > 0 {
-                    s.history_turn = Some(turn - 1);
-                } else {
-                    s.history_turn = None;
-                }
-            };
-        })
+    pub fn undo_n_moves(&self, n: usize) {
+        if let Some(turn) = self.history_turn().get() {
+            self.state().update(|s| s.undo(n));
+            if turn >= n {
+                self.history_turn().set(Some(turn - n));
+            } else {
+                self.history_turn().set(None);
+            }
+        }
     }
-
     pub fn set_game_status(&self, status: GameStatus) {
         self.state().update(|state| {
             state.game_status = status;
@@ -147,20 +143,20 @@ impl GameStateStore {
         self.move_info().update(|move_info| move_info.reset())
     }
 
-    pub fn move_active(&self, analysis: Option<AnalysisSignal>, api: ApiRequests) {
-        self.0.update(|s| s.move_active(analysis, api))
+    pub fn move_active(&self, analysis: Option<AnalysisStore>, api: ApiRequests) {
+        self.update(|s| s.move_active(analysis, api))
     }
 
     pub fn is_move_allowed(&self, in_analysis: bool) -> bool {
-        self.0.with_untracked(|gs| gs.is_move_allowed(in_analysis))
+        self.with_untracked(|gs| gs.is_move_allowed(in_analysis))
     }
 
     pub fn show_moves(&self, piece: Piece, position: Position) {
-        self.0.update(|s| s.show_moves(piece, position))
+        self.update(|s| s.show_moves(piece, position))
     }
 
     pub fn show_spawns(&self, piece: Piece, position: Position) {
-        self.0.update(|s| s.show_spawns(piece, position))
+        self.update(|s| s.show_spawns(piece, position))
     }
 
     pub fn set_target(&self, position: Position) {
@@ -361,24 +357,25 @@ impl GameState {
         })
     }
 
-    pub fn move_active(&mut self, analysis: Option<AnalysisSignal>, api: ApiRequests) {
+    pub fn move_active(&mut self, analysis: Option<AnalysisStore>, api: ApiRequests) {
         if let (Some((active, _)), Some(position)) =
             (self.move_info.active, self.move_info.target_position)
         {
             if let Err(e) = self.state.play_turn_from_position(active, position) {
                 log!("Could not play turn: {} {} {}", active, position, e);
             } else if let Some(analysis) = analysis {
-                analysis.0.update(|analysis| {
-                    let moves = self.state.history.moves.clone();
-                    let hashes = self.state.hashes.clone();
-                    let last_index = moves.len() - 1;
-                    if moves[last_index].0 == "pass" {
-                        //if move is pass, add prev move
-                        analysis.add_node(moves[last_index - 1].clone(), hashes[last_index - 1]);
-                    }
-                    analysis.add_node(moves[last_index].clone(), hashes[last_index]);
-                    self.move_info.reset();
-                });
+                let moves = self.state.history.moves.clone();
+                let hashes = self.state.hashes.clone();
+                let last_index = moves.len() - 1;
+                if moves[last_index].0 == "pass" {
+                    //if move is pass, add prev move
+                    analysis.update(|a| {
+                        a.add_node(moves[last_index - 1].clone(), hashes[last_index - 1])
+                    });
+                }
+                analysis.update(|a| a.add_node(moves[last_index].clone(), hashes[last_index]));
+                self.history_turn = Some(moves.len());
+                self.move_info.reset();
             } else if let Some(ref game_id) = self.game_id {
                 let turn = Turn::Move(active, position);
                 api.turn(game_id.to_owned(), turn);

--- a/apis/src/websocket/client_handlers/game/handler.rs
+++ b/apis/src/websocket/client_handlers/game/handler.rs
@@ -1,7 +1,7 @@
 use super::reaction::{handle_control, handle_new_game};
 use crate::{
     common::{GameActionResponse, GameReaction, GameUpdate},
-    providers::{game_state::GameStateSignal, games::GamesSignal, UpdateNotifier},
+    providers::{game_state::GameStateStore, games::GamesSignal, UpdateNotifier},
     responses::GameResponse,
 };
 use hive_lib::{GameStatus, History, State};
@@ -97,7 +97,7 @@ fn handle_reaction(gar: GameActionResponse) {
     };
 }
 
-pub fn reset_game_state_for_takeback(game: &GameResponse, game_state: &mut GameStateSignal) {
+pub fn reset_game_state_for_takeback(game: &GameResponse, game_state: &GameStateStore) {
     game_state.view_game();
     game_state.set_game_response(game.clone());
     let mut history = History::new();
@@ -108,11 +108,9 @@ pub fn reset_game_state_for_takeback(game: &GameResponse, game_state: &mut GameS
     };
 }
 
-pub fn reset_game_state(game: &GameResponse, mut game_state: GameStateSignal) {
+pub fn reset_game_state(game: &GameResponse, game_state: GameStateStore) {
     game_state.full_reset();
-    game_state
-        .signal
-        .update_untracked(|gs| gs.game_id = Some(game.game_id.clone()));
+    game_state.update_untracked(|gs| gs.game_id = Some(game.game_id.clone()));
     game_state.set_game_response(game.clone());
     let mut history = History::new();
     game.history.clone_into(&mut history.moves);

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -60,9 +60,11 @@ impl State {
         Ok(state)
     }
 
-    pub fn undo(&mut self) {
+    pub fn undo(&mut self, n: usize) {
         let mut moves = self.history.moves.clone();
-        moves.pop();
+        for _ in 0..n {
+            moves.pop();
+        }
         let moves = moves
             .iter()
             .map(|(piece, mov)| format!("{piece} {mov}"))


### PR DESCRIPTION
- Uses a Store for analysis

- ~Loads Analysis with a OnceResource and avoids the suspend barrier~ Use a local resource, no reason no load this in the server. Do a simple refactor for readability but the suspend barrier when providing the context makes sense and should be required (ion is always right :D)

- Ensures uhp strings and the move param in the query can be used in tandem

- Only move in analysis history if arrow is pressed without any modifiers. (Fixes https://github.com/hiveboardgame/hive/issues/691)

### Created the full_path field in Analysis tree
This maintains a full path from root to leaf of a "best guess" for the possible variation the user wants to traverse. Then instead of redrawing everything, jump forward or backward a few moves. It has the following advantages:
- The arrows work fast since a single step is very quick to do.
- Jumping to "near" points in the tree is quick
- In the worst case we need to recompute the full path, which wont happen if the tree isnt to dense.  And even then, recomputing the full path for a 150~200 nodes is not that bad.
- Its not required to serialized and can be reconstructed from the rest of the data

#### Requires https://github.com/hiveboardgame/hive/pull/703

Hopefully fixes https://github.com/hiveboardgame/hive/issues/508 and https://github.com/hiveboardgame/hive/issues/696