### PR TITLE
Auto-accept takebacks in bot games

### DIFF
--- a/apis/src/api/v1/bot/play.rs
+++ b/apis/src/api/v1/bot/play.rs
@@ -201,6 +201,16 @@ async fn handle_control(
             }
             GameControl::Abort(bot_color)
         }
+        "takeback_accept" => {
+            if game.turn < 2 {
+                return Err(anyhow!("Cannot accept takeback before turn 2"));
+            }
+            let expected = GameControl::TakebackRequest(bot_color.opposite_color());
+            if game.last_game_control() != Some(expected) {
+                return Err(anyhow!("No pending takeback request to accept"));
+            }
+            GameControl::TakebackAccept(bot_color)
+        }
         _ => return Err(anyhow!("Invalid control type: {}", req.control)),
     };
 
@@ -221,6 +231,7 @@ async fn handle_control(
                         game_copy.finished = true;
                         game_copy
                     }
+                    GameControl::TakebackAccept(_) => game.accept_takeback(&game_control, tc).await?,
                     _ => unreachable!(),
                 };
 

--- a/apis/src/websocket/server_handlers/game/control_handler.rs
+++ b/apis/src/websocket/server_handlers/game/control_handler.rs
@@ -67,17 +67,22 @@ impl GameControlHandler {
                 username: self.username.to_owned(),
             }))),
         });
-        match self.control {
-            GameControl::DrawOffer(_) | GameControl::TakebackRequest(_) => {
-                let current_user = User::find_by_uuid(&game.current_player_id, &mut conn).await?;
-                let games = current_user.get_games_with_notifications(&mut conn).await?;
-                let game_responses = GameResponse::from_games_batch(games, &mut conn).await?;
-                messages.push(InternalServerMessage {
-                    destination: MessageDestination::User(game.current_player_id),
-                    message: ServerMessage::Game(Box::new(GameUpdate::Urgent(game_responses))),
-                });
+
+        // Only notify the opponent about a *pending* control.
+        if game.has_unanswered_game_control() {
+            match self.control {
+                GameControl::DrawOffer(_) | GameControl::TakebackRequest(_) => {
+                    let current_user =
+                        User::find_by_uuid(&game.current_player_id, &mut conn).await?;
+                    let games = current_user.get_games_with_notifications(&mut conn).await?;
+                    let game_responses = GameResponse::from_games_batch(games, &mut conn).await?;
+                    messages.push(InternalServerMessage {
+                        destination: MessageDestination::User(game.current_player_id),
+                        message: ServerMessage::Game(Box::new(GameUpdate::Urgent(game_responses))),
+                    });
+                }
+                _ => {}
             }
-            _ => {}
         }
         if game_response.time_mode == TimeMode::RealTime {
             messages.push(InternalServerMessage {
@@ -123,19 +128,16 @@ impl GameControlHandler {
     }
 
     async fn handle_takeback_request(&self, conn: &mut DbConn<'_>) -> Result<Game> {
-        let game = self.game.write_game_control(&self.control, conn).await?;
-        Ok(game)
+        Ok(self.game.write_game_control(&self.control, conn).await?)
     }
 
     async fn handle_takeback_accept(&self, conn: &mut DbConn<'_>) -> Result<Game> {
         self.ensure_previous_gc_present()?;
-        let game = self.game.accept_takeback(&self.control, conn).await?;
-        Ok(game)
+        Ok(self.game.accept_takeback(&self.control, conn).await?)
     }
 
     async fn handle_resign(&self, conn: &mut DbConn<'_>) -> Result<Game> {
-        let game = self.game.resign(&self.control, conn).await?;
-        Ok(game)
+        Ok(self.game.resign(&self.control, conn).await?)
     }
 
     async fn handle_abort(&self, conn: &mut DbConn<'_>) -> Result<()> {
@@ -147,25 +149,21 @@ impl GameControlHandler {
 
     async fn handle_draw_reject(&self, conn: &mut DbConn<'_>) -> Result<Game> {
         self.ensure_previous_gc_present()?;
-        let game = self.game.write_game_control(&self.control, conn).await?;
-        Ok(game)
+        Ok(self.game.write_game_control(&self.control, conn).await?)
     }
 
     async fn handle_draw_offer(&self, conn: &mut DbConn<'_>) -> Result<Game> {
-        let game = self.game.write_game_control(&self.control, conn).await?;
-        Ok(game)
+        Ok(self.game.write_game_control(&self.control, conn).await?)
     }
 
     async fn handle_draw_accept(&self, conn: &mut DbConn<'_>) -> Result<Game> {
         self.ensure_previous_gc_present()?;
-        let game = self.game.accept_draw(&self.control, conn).await?;
-        Ok(game)
+        Ok(self.game.accept_draw(&self.control, conn).await?)
     }
 
     async fn handle_takeback_reject(&self, conn: &mut DbConn<'_>) -> Result<Game> {
         self.ensure_previous_gc_present()?;
-        let game = self.game.write_game_control(&self.control, conn).await?;
-        Ok(game)
+        Ok(self.game.write_game_control(&self.control, conn).await?)
     }
 
     async fn match_control(&self, conn: &mut DbConn<'_>) -> Result<Game> {

--- a/hive-hydra/src/bot.rs
+++ b/hive-hydra/src/bot.rs
@@ -5,15 +5,24 @@ use crate::{
     BotGameTurn,
 };
 use std::{
+    collections::HashMap,
     sync::Arc,
     time::{Duration, Instant},
 };
 use tokio::sync::{mpsc, Mutex, Semaphore};
+use tokio::task::JoinHandle;
 use tracing::{debug, error, info};
 
 // Constants for token and login management
 const LOGIN_RETRY_INTERVAL_SECS: u64 = 10;
 const TOKEN_REFRESH_INTERVAL_SECS: u64 = 3600; // Refresh token every 60 minutes
+
+fn has_pending_takeback_request(game_control_history: &str) -> bool {
+    game_control_history
+        .split_terminator(';')
+        .next_back()
+        .is_some_and(|entry| entry.contains("TakebackRequest("))
+}
 
 async fn auth(api: &HiveGameApi, bot: &BotConfig) -> String {
     // Authenticate to get token with retry logic
@@ -96,6 +105,30 @@ pub async fn producer_task(
                     bot.name
                 );
                 for game in game_strings {
+                    // If there's a pending takeback request, auto-accept immediately.
+                    // These "pending" games are fetched from the server's notifications list,
+                    // so a takeback request here is directed at the bot.
+                    if has_pending_takeback_request(&game.game_control_history) {
+                        let game_identifier = match &game.nanoid {
+                            Some(id) => id.clone(),
+                            None => game.game_id.clone(),
+                        };
+                        match api
+                            .control_game(&game_identifier, "takeback_accept", &token)
+                            .await
+                        {
+                            Ok(()) => debug!(
+                                "Auto-accepted takeback for game {} (bot {})",
+                                game_identifier, bot.name
+                            ),
+                            Err(e) => error!(
+                                "Failed to auto-accept takeback for game {} (bot {}): {}",
+                                game_identifier, bot.name, e
+                            ),
+                        }
+                        continue;
+                    }
+
                     let hash = game.hash();
 
                     if turn_tracker.tracked(hash).await {
@@ -130,7 +163,7 @@ pub async fn producer_task(
 pub async fn consumer_task(
     receiver: Arc<Mutex<mpsc::Receiver<BotGameTurn>>>,
     semaphore: Arc<Semaphore>,
-    active_processes: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    active_processes: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     turn_tracker: TurnTracker,
     api: Arc<HiveGameApi>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -143,6 +176,20 @@ pub async fn consumer_task(
             debug!("Received turn for bot {}", turn.bot.name);
 
             let api_clone = api.clone();
+
+            // Prefer nanoid (web UI game id), fall back to numeric game id.
+            let game_identifier = match &turn.game.nanoid {
+                Some(id) => id.clone(),
+                None => turn.game.game_id.clone(),
+            };
+
+            // If we're already thinking about this game (e.g. a takeback happened),
+            // abort the previous task and replace it with a fresh computation.
+            if let Some(previous) = active_processes.lock().await.remove(&game_identifier) {
+                previous.abort();
+                debug!("Aborted previous processing for game {}", game_identifier);
+            }
+
             let handle = tokio::spawn(process_turn(
                 turn,
                 semaphore.clone(),
@@ -150,7 +197,10 @@ pub async fn consumer_task(
                 api_clone,
             ));
 
-            active_processes.lock().await.push(handle);
+            active_processes
+                .lock()
+                .await
+                .insert(game_identifier, handle);
             cleanup_processes(active_processes.clone()).await;
         }
     }
@@ -244,10 +294,10 @@ async fn process_turn(
     );
 }
 
-pub async fn cleanup_processes(active_processes: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>) {
+pub async fn cleanup_processes(active_processes: Arc<Mutex<HashMap<String, JoinHandle<()>>>>) {
     let mut processes = active_processes.lock().await;
     let initial_count = processes.len();
-    processes.retain(|handle| !handle.is_finished());
+    processes.retain(|_, handle| !handle.is_finished());
     let removed = initial_count - processes.len();
     if removed > 0 {
         debug!("Cleaned up {} finished processes", removed);

--- a/hive-hydra/src/hivegame_bot_api.rs
+++ b/hive-hydra/src/hivegame_bot_api.rs
@@ -37,6 +37,8 @@ pub struct HiveGame {
     pub player_turn: String,
     #[serde(rename = "history", default)]
     pub moves: String,
+    #[serde(default)]
+    pub game_control_history: String,
     // Additional fields from API response - we can ignore most of these
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nanoid: Option<String>,
@@ -128,6 +130,12 @@ impl HiveGame {
 struct PlayMove {
     game_id: String,
     piece_pos: String,
+}
+
+#[derive(Debug, Serialize)]
+struct GameControlRequest {
+    game_id: String,
+    control: String,
 }
 
 pub struct HiveGameApi {
@@ -233,6 +241,37 @@ impl HiveGameApi {
             });
         }
 
+        Ok(())
+    }
+
+    /// Send a game control to the server (e.g. takeback_accept)
+    pub async fn control_game(
+        &self,
+        game_id: &str,
+        control: &str,
+        token: &str,
+    ) -> Result<(), ApiError> {
+        let url = format!("{}/api/v1/bot/games/control", self.base_url);
+        let payload = GameControlRequest {
+            game_id: game_id.to_string(),
+            control: control.to_string(),
+        };
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .json(&payload)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(ApiError::Server {
+                status_code: status,
+                message: response.text().await.unwrap_or_default(),
+            });
+        }
         Ok(())
     }
 

--- a/hive-hydra/src/main.rs
+++ b/hive-hydra/src/main.rs
@@ -1,5 +1,5 @@
 use hivegame_bot_api::HiveGame;
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::{mpsc, Mutex, Semaphore};
 use tracing::{debug, error, info};
 
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (sender, receiver) = mpsc::channel(config.queue_capacity);
     let receiver = Arc::new(Mutex::new(receiver));
     let semaphore = Arc::new(Semaphore::new(config.max_concurrent_processes));
-    let active_processes = Arc::new(Mutex::new(Vec::new()));
+    let active_processes = Arc::new(Mutex::new(HashMap::new()));
     let turn_tracker = TurnTracker::new();
 
     info!(


### PR DESCRIPTION
Bots now auto-accept pending takeback requests and cancel/restart any in-flight thinking for that game. The bot control API adds support for takeback acceptance.
