### PR TITLE
Makes engine go brrr

### DIFF
--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -284,7 +284,8 @@ impl Board {
     ) -> u64 {
         if self.played == 1 {
             let bs = self.board.get_mut(Position::initial_spawn_position());
-            bs.index = [Some(0), Some(0)];
+            bs.set_index(Rotation::C, 0);
+            bs.set_index(Rotation::CC, 0);
             self.smallest = Some((piece, to));
             self.hasher.update(bs, Some(0), Rotation::C);
             self.hasher.update(bs, Some(0), Rotation::CC);
@@ -310,7 +311,7 @@ impl Board {
             }
 
             let mut stack = self.board.get(to).clone();
-            if stack.index != [None, None] {
+            if stack.has_index() {
                 let top_piece = stack.pop_piece();
                 debug_assert_eq!(piece, top_piece);
                 self.hasher.update(&stack, None, Rotation::C);
@@ -326,8 +327,8 @@ impl Board {
                 counter_clockwise.take_while(|pos| *pos != to).count(),
             );
             let stack = self.board.get_mut(to);
-            stack.index[Rotation::C as usize] = Some(c_index);
-            stack.index[Rotation::CC as usize] = Some(cc_index);
+            stack.set_index(Rotation::C, c_index);
+            stack.set_index(Rotation::CC, cc_index);
             self.hasher.update(stack, Some(c_index as u32), Rotation::C);
             self.hasher
                 .update(stack, Some(cc_index as u32), Rotation::CC);
@@ -339,7 +340,7 @@ impl Board {
             let mut hashed = 0_usize;
             for (index, position) in clockwise.enumerate() {
                 let bs = self.board.get_mut(position);
-                bs.index[Rotation::C as usize] = Some(index);
+                bs.set_index(Rotation::C, index);
                 if !bs.is_empty() {
                     self.hasher.update(bs, Some(index as u32), Rotation::C);
                     hashed += bs.size as usize;
@@ -353,7 +354,7 @@ impl Board {
             hashed = 0_usize;
             for (index, position) in counter_clockwise.enumerate() {
                 let bs = self.board.get_mut(position);
-                bs.index[Rotation::CC as usize] = Some(index);
+                bs.set_index(Rotation::CC, index);
                 if !bs.is_empty() {
                     self.hasher.update(bs, Some(index as u32), Rotation::CC);
                     hashed += bs.size as usize;
@@ -734,10 +735,61 @@ impl Board {
         current_position: Position,
         target_position: Position,
     ) -> bool {
-        match self.moves(color).get(&(piece, current_position)) {
-            None => false,
-            Some(positions) => positions.contains(&target_position),
+        match self.game_result() {
+            GameResult::Unknown => {}
+            _ => return false,
         }
+        if !self.queen_played(color) {
+            return false;
+        }
+        if self.top_piece(current_position) != Some(piece) {
+            return false;
+        }
+        if self.last_moved == Some((piece, current_position)) {
+            return false;
+        }
+
+        if piece.is_color(color) {
+            if let Some(positions) =
+                Bug::available_moves(current_position, self).get(&current_position)
+            {
+                if positions.contains(&target_position) {
+                    return true;
+                }
+            }
+        }
+
+        for (_, ability_position) in self.ability_pieces_around(color, current_position) {
+            if let Some(positions) =
+                Bug::available_abilities(ability_position, self).get(&current_position)
+            {
+                if positions.contains(&target_position) {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    fn ability_pieces_around(
+        &self,
+        color: Color,
+        position: Position,
+    ) -> impl Iterator<Item = (Piece, Position)> + '_ {
+        position.positions_around().filter_map(move |pos| {
+            let piece = self.top_piece(pos)?;
+            if !piece.is_color(color) || self.last_moved == Some((piece, pos)) {
+                return None;
+            }
+            match piece.bug() {
+                Bug::Pillbug => Some((piece, pos)),
+                Bug::Mosquito if self.level(pos) == 1 && self.neighbor_is_a(pos, Bug::Pillbug) => {
+                    Some((piece, pos))
+                }
+                _ => None,
+            }
+        })
     }
 
     pub fn moves(&self, color: Color) -> HashMap<(Piece, Position), Vec<Position>> {

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -239,15 +239,13 @@ impl Bug {
 
     fn crawl(position: Position, board: &Board) -> impl Iterator<Item = Position> + '_ {
         board.positions_taken_around(position).flat_map(move |pos| {
-            let mut positions = vec![];
             let (pos1, pos2) = position.common_adjacent_positions(pos);
-            if !board.gated(1, position, pos1) && !board.occupied(pos1) {
-                positions.push(pos1);
-            }
-            if !board.gated(1, position, pos2) && !board.occupied(pos2) {
-                positions.push(pos2);
-            }
-            positions
+            [
+                (!board.gated(1, position, pos1) && !board.occupied(pos1)).then_some(pos1),
+                (!board.gated(1, position, pos2) && !board.occupied(pos2)).then_some(pos2),
+            ]
+            .into_iter()
+            .flatten()
         })
     }
 

--- a/engine/src/bug_stack.rs
+++ b/engine/src/bug_stack.rs
@@ -1,12 +1,14 @@
 use itertools::Itertools;
 
-use crate::{color::Color, piece::Piece};
+use crate::{color::Color, piece::Piece, position::Rotation};
 use std::fmt;
+
+const MISSING_INDEX: u16 = u16::MAX;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BugStack {
     pub pieces: [Piece; 7],
-    pub index: [Option<usize>; 2],
+    index: [u16; 2],
     pub size: u8,
 }
 
@@ -32,7 +34,7 @@ impl BugStack {
     pub fn new() -> Self {
         Self {
             pieces: [Piece::new().with_invalid(true); 7],
-            index: [None, None],
+            index: [MISSING_INDEX, MISSING_INDEX],
             size: 0,
         }
     }
@@ -81,6 +83,23 @@ impl BugStack {
 
     pub fn is_empty(&self) -> bool {
         self.size == 0
+    }
+
+    pub fn has_index(&self) -> bool {
+        self.index.iter().any(|index| *index != MISSING_INDEX)
+    }
+
+    pub fn index(&self, rotation: Rotation) -> Option<usize> {
+        let index = self.index[rotation as usize];
+        if index == MISSING_INDEX {
+            None
+        } else {
+            Some(index as usize)
+        }
+    }
+
+    pub fn set_index(&mut self, rotation: Rotation, index: usize) {
+        self.index[rotation as usize] = u16::try_from(index).expect("BugStack index fits in u16");
     }
 
     pub fn top_bug_color(&self) -> Option<Color> {

--- a/engine/src/hasher.rs
+++ b/engine/src/hasher.rs
@@ -40,7 +40,7 @@ impl Hasher {
         }
         let index = if let Some(index) = index {
             index as u64
-        } else if let Some(index) = bug_stack.index[revolution as usize] {
+        } else if let Some(index) = bug_stack.index(revolution) {
             index as u64
         } else {
             panic!("We need an index");


### PR DESCRIPTION
  - Speedup: about 1.6x
  - Throughput: ~1.59M successful replay moves/s -> ~2.54M successful replay moves/s
    - Much smaller engine state:
      - BugStack: 40 B -> 12 B
      - Board: 42,752 B -> 14,048 B
      - State: 42,928 B -> 14,224 B
  - Less copying when Board/State are cloned or moved.