### PR TITLE
Engine performance improvements

### DIFF
--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -611,9 +611,10 @@ impl Board {
             });
         }
 
+        let ground_graph_changes = self.level(current) == 1 || !self.occupied(target);
         let removed_piece = self.remove(current);
         debug_assert_eq!(removed_piece, piece);
-        self.insert(target, piece, false);
+        self.insert_with_pinned_update(target, piece, false, ground_graph_changes);
         Ok(())
     }
 
@@ -1112,6 +1113,16 @@ impl Board {
 
     /// @neal - add piece
     pub fn insert(&mut self, position: Position, piece: Piece, spawn: bool) {
+        self.insert_with_pinned_update(position, piece, spawn, true);
+    }
+
+    fn insert_with_pinned_update(
+        &mut self,
+        position: Position,
+        piece: Piece,
+        spawn: bool,
+        update_pinned: bool,
+    ) {
         self.last_moved = Some((piece, position));
         let stack = self.board.get_mut(position);
         stack.push_piece(piece);
@@ -1119,7 +1130,9 @@ impl Board {
         if self.board.get(position).size == 1 {
             self.neighbor_count_add(position)
         }
-        self.update_pinned();
+        if update_pinned {
+            self.update_pinned();
+        }
         if spawn {
             self.played += 1;
         }

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -284,7 +284,8 @@ impl Board {
     ) -> u64 {
         if self.played == 1 {
             let bs = self.board.get_mut(Position::initial_spawn_position());
-            bs.index = [Some(0), Some(0)];
+            bs.set_index(Rotation::C, 0);
+            bs.set_index(Rotation::CC, 0);
             self.smallest = Some((piece, to));
             self.hasher.update(bs, Some(0), Rotation::C);
             self.hasher.update(bs, Some(0), Rotation::CC);
@@ -310,7 +311,7 @@ impl Board {
             }
 
             let mut stack = self.board.get(to).clone();
-            if stack.index != [None, None] {
+            if stack.has_index() {
                 let top_piece = stack.pop_piece();
                 debug_assert_eq!(piece, top_piece);
                 self.hasher.update(&stack, None, Rotation::C);
@@ -326,8 +327,8 @@ impl Board {
                 counter_clockwise.take_while(|pos| *pos != to).count(),
             );
             let stack = self.board.get_mut(to);
-            stack.index[Rotation::C as usize] = Some(c_index);
-            stack.index[Rotation::CC as usize] = Some(cc_index);
+            stack.set_index(Rotation::C, c_index);
+            stack.set_index(Rotation::CC, cc_index);
             self.hasher.update(stack, Some(c_index as u32), Rotation::C);
             self.hasher
                 .update(stack, Some(cc_index as u32), Rotation::CC);
@@ -339,7 +340,7 @@ impl Board {
             let mut hashed = 0_usize;
             for (index, position) in clockwise.enumerate() {
                 let bs = self.board.get_mut(position);
-                bs.index[Rotation::C as usize] = Some(index);
+                bs.set_index(Rotation::C, index);
                 if !bs.is_empty() {
                     self.hasher.update(bs, Some(index as u32), Rotation::C);
                     hashed += bs.size as usize;
@@ -353,7 +354,7 @@ impl Board {
             hashed = 0_usize;
             for (index, position) in counter_clockwise.enumerate() {
                 let bs = self.board.get_mut(position);
-                bs.index[Rotation::CC as usize] = Some(index);
+                bs.set_index(Rotation::CC, index);
                 if !bs.is_empty() {
                     self.hasher.update(bs, Some(index as u32), Rotation::CC);
                     hashed += bs.size as usize;
@@ -734,10 +735,61 @@ impl Board {
         current_position: Position,
         target_position: Position,
     ) -> bool {
-        match self.moves(color).get(&(piece, current_position)) {
-            None => false,
-            Some(positions) => positions.contains(&target_position),
+        match self.game_result() {
+            GameResult::Unknown => {}
+            _ => return false,
         }
+        if !self.queen_played(color) {
+            return false;
+        }
+        if self.top_piece(current_position) != Some(piece) {
+            return false;
+        }
+        if self.last_moved == Some((piece, current_position)) {
+            return false;
+        }
+
+        if piece.is_color(color) {
+            if let Some(positions) =
+                Bug::available_moves(current_position, self).get(&current_position)
+            {
+                if positions.contains(&target_position) {
+                    return true;
+                }
+            }
+        }
+
+        for (_, ability_position) in self.ability_pieces_around(color, current_position) {
+            if let Some(positions) =
+                Bug::available_abilities(ability_position, self).get(&current_position)
+            {
+                if positions.contains(&target_position) {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    fn ability_pieces_around(
+        &self,
+        color: Color,
+        position: Position,
+    ) -> impl Iterator<Item = (Piece, Position)> + '_ {
+        position.positions_around().filter_map(move |pos| {
+            let piece = self.top_piece(pos)?;
+            if !piece.is_color(color) || self.last_moved == Some((piece, pos)) {
+                return None;
+            }
+            match piece.bug() {
+                Bug::Pillbug => Some((piece, pos)),
+                Bug::Mosquito if self.level(pos) == 1 && self.neighbor_is_a(pos, Bug::Pillbug) => {
+                    Some((piece, pos))
+                }
+                _ => None,
+            }
+        })
     }
 
     pub fn moves(&self, color: Color) -> HashMap<(Piece, Position), Vec<Position>> {

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -818,7 +818,7 @@ impl Board {
 
         if piece.is_color(color)
             && !self.is_pinned(piece)
-            && Bug::normal_moves(current_position, self).contains(&target_position)
+            && Bug::has_target_move(current_position, target_position, self)
         {
             return true;
         }

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -824,7 +824,7 @@ impl Board {
         }
 
         for (_, ability_position) in self.ability_pieces_around(color, current_position) {
-            if Bug::can_throw(ability_position, current_position, target_position, self) {
+            if Bug::can_throw_piece_to(ability_position, current_position, target_position, self) {
                 return true;
             }
         }

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -26,6 +26,7 @@ use std::{
 };
 
 pub const BOARD_SIZE: i32 = 32;
+const MISSING_DFS_INDEX: u8 = u8::MAX;
 lazy_static! {
     static ref BLACK_QUEEN: Piece = Piece::new_from(Bug::Queen, Color::Black, 0);
     static ref WHITE_QUEEN: Piece = Piece::new_from(Bug::Queen, Color::White, 0);
@@ -913,68 +914,91 @@ impl Board {
     }
 
     pub fn update_pinned(&mut self) {
-        for pinned_info in self.calculate_pinned().iter() {
-            self.pinned[self.piece_to_offset(pinned_info.piece)] = pinned_info.pinned
-        }
+        self.calculate_pinned().into_iter().for_each(|pinned_info| {
+            let offset = self.piece_to_offset(pinned_info.piece);
+            self.pinned[offset] = pinned_info.pinned;
+        });
     }
 
     pub fn calculate_pinned(&self) -> Vec<DfsInfo> {
-        // make sure to get only top pieces in this
-        let mut dfs_info = self
-            .positions
-            .iter()
-            .enumerate()
-            .filter_map(|(i, maybe_pos)| {
-                if let Some(pos) = maybe_pos {
-                    if self.is_bottom_piece(self.offset_to_piece(i), *pos) {
-                        Some(DfsInfo {
-                            position: *pos,
-                            piece: self.bottom_piece(*pos).unwrap(),
-                            visited: false,
-                            depth: 0,
-                            low: 0,
-                            pinned: false,
-                            parent: None,
-                        })
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+        // Connectivity is position-based, so stacked positions contribute only their bottom piece.
+        let mut dfs_info = Vec::with_capacity(self.played);
+        let mut dfs_indexes = TorusArray::new(MISSING_DFS_INDEX);
+
+        for (i, maybe_pos) in self.positions.iter().enumerate() {
+            let Some(pos) = maybe_pos else {
+                continue;
+            };
+            let piece = self.offset_to_piece(i);
+
+            if self.is_bottom_piece(piece, *pos) {
+                let dfs_index = dfs_info.len();
+                debug_assert!(dfs_index < usize::from(MISSING_DFS_INDEX));
+
+                dfs_indexes.set(*pos, dfs_index as u8);
+                dfs_info.push(DfsInfo {
+                    position: *pos,
+                    piece,
+                    visited: false,
+                    depth: 0,
+                    low: 0,
+                    pinned: false,
+                    parent: None,
+                });
+            }
+        }
+
         if dfs_info.is_empty() {
             return dfs_info;
         }
-        self.bcc(0, 0, &mut dfs_info);
+        self.mark_articulation_points(0, 0, &mut dfs_info, &dfs_indexes);
         dfs_info
     }
 
-    pub fn bcc(&self, i: usize, d: usize, dfs_info: &mut Vec<DfsInfo>) {
-        dfs_info[i].visited = true;
-        dfs_info[i].depth = d;
-        dfs_info[i].low = d;
+    fn mark_articulation_points(
+        &self,
+        index: usize,
+        depth: usize,
+        dfs_info: &mut [DfsInfo],
+        dfs_indexes: &TorusArray<u8>,
+    ) {
+        dfs_info[index].visited = true;
+        dfs_info[index].depth = depth;
+        dfs_info[index].low = depth;
         let mut child_count = 0;
-        let mut ap = false;
+        let mut is_articulation_point = false;
 
-        for pos in self.positions_taken_around(dfs_info[i].position) {
-            let ni = dfs_info.iter().position(|e| e.position == pos).unwrap();
-            if !dfs_info[ni].visited {
+        for pos in self.positions_taken_around(dfs_info[index].position) {
+            let neighbor_dfs_index = usize::from(*dfs_indexes.get(pos));
+            debug_assert!(
+                neighbor_dfs_index < dfs_info.len(),
+                "Occupied position should have a DFS index"
+            );
+
+            if !dfs_info[neighbor_dfs_index].visited {
                 child_count += 1;
-                dfs_info[ni].parent = Some(i);
-                self.bcc(ni, d + 1, dfs_info);
-                if dfs_info[ni].low >= dfs_info[i].depth {
-                    ap = true;
+                dfs_info[neighbor_dfs_index].parent = Some(index);
+                self.mark_articulation_points(neighbor_dfs_index, depth + 1, dfs_info, dfs_indexes);
+                if dfs_info[neighbor_dfs_index].low >= dfs_info[index].depth {
+                    is_articulation_point = true;
                 }
-                dfs_info[i].low = std::cmp::min(dfs_info[i].low, dfs_info[ni].low);
-            } else if dfs_info[i].parent.is_some() && ni != dfs_info[i].parent.unwrap() {
-                dfs_info[i].low = std::cmp::min(dfs_info[i].low, dfs_info[ni].depth);
+                dfs_info[index].low =
+                    std::cmp::min(dfs_info[index].low, dfs_info[neighbor_dfs_index].low);
+            } else {
+                let is_alternate_connection = dfs_info[index]
+                    .parent
+                    .is_some_and(|parent_dfs_index| neighbor_dfs_index != parent_dfs_index);
+                if is_alternate_connection {
+                    dfs_info[index].low =
+                        std::cmp::min(dfs_info[index].low, dfs_info[neighbor_dfs_index].depth);
+                }
             }
         }
-        if dfs_info[i].parent.is_some() && ap || (dfs_info[i].parent.is_none() && child_count > 1) {
-            dfs_info[i].pinned = true;
+
+        if dfs_info[index].parent.is_none() {
+            is_articulation_point = child_count > 1;
         }
+        dfs_info[index].pinned = is_articulation_point;
     }
 
     pub fn top_layer_neighbors(&self, position: Position) -> impl Iterator<Item = Piece> + '_ {

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -749,23 +749,16 @@ impl Board {
             return false;
         }
 
-        if piece.is_color(color) {
-            if let Some(positions) =
-                Bug::available_moves(current_position, self).get(&current_position)
-            {
-                if positions.contains(&target_position) {
-                    return true;
-                }
-            }
+        if piece.is_color(color)
+            && !self.is_pinned(piece)
+            && Bug::normal_moves(current_position, self).contains(&target_position)
+        {
+            return true;
         }
 
         for (_, ability_position) in self.ability_pieces_around(color, current_position) {
-            if let Some(positions) =
-                Bug::available_abilities(ability_position, self).get(&current_position)
-            {
-                if positions.contains(&target_position) {
-                    return true;
-                }
+            if Bug::can_throw(ability_position, current_position, target_position, self) {
+                return true;
             }
         }
 

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -567,10 +567,10 @@ impl Board {
     pub fn game_result(&self) -> GameResult {
         let black_won = self
             .position_of_piece(*WHITE_QUEEN)
-            .map(|pos| self.neighbors(pos).count() == 6);
+            .map(|pos| *self.neighbor_count.get(pos) == 6);
         let white_won = self
             .position_of_piece(*BLACK_QUEEN)
-            .map(|pos| self.neighbors(pos).count() == 6);
+            .map(|pos| *self.neighbor_count.get(pos) == 6);
         match (black_won, white_won) {
             (Some(true), Some(true)) => GameResult::Draw,
             (Some(true), Some(false)) => GameResult::Winner(Color::Black),
@@ -873,13 +873,13 @@ impl Board {
                             continue;
                         }
                     }
-                    for (start_pos, target_positions) in Bug::available_moves(*pos, self) {
+                    for (start_pos, mut target_positions) in Bug::available_moves(*pos, self) {
                         if let Some(piece) = self.top_piece(start_pos) {
                             if !target_positions.is_empty() {
                                 moves
                                     .entry((piece, start_pos))
                                     .or_default()
-                                    .append(&mut target_positions.clone());
+                                    .append(&mut target_positions);
                             }
                         }
                     }
@@ -894,9 +894,10 @@ impl Board {
     }
 
     pub fn spawnable_positions(&self, color: Color) -> impl Iterator<Item = Position> + '_ {
+        let game_result = self.game_result();
         std::iter::once(Position::initial_spawn_position())
             .chain(self.negative_space())
-            .filter(move |pos| self.spawnable(color, *pos))
+            .filter(move |pos| self.spawnable_with_game_result(color, *pos, &game_result))
     }
 
     pub fn queen_played(&self, color: Color) -> bool {
@@ -1054,9 +1055,17 @@ impl Board {
     }
 
     pub fn spawnable(&self, color: Color, position: Position) -> bool {
-        match self.game_result() {
-            GameResult::Unknown => {}
-            _ => return false,
+        self.spawnable_with_game_result(color, position, &self.game_result())
+    }
+
+    fn spawnable_with_game_result(
+        &self,
+        color: Color,
+        position: Position,
+        game_result: &GameResult,
+    ) -> bool {
+        if !matches!(game_result, GameResult::Unknown) {
+            return false;
         }
         if self.occupied(position) {
             return false;
@@ -1067,13 +1076,12 @@ impl Board {
         if self.played == 1 {
             return self.is_negative_space(position);
         }
-        // connected to the hive
-        if self.top_layer_neighbors(position).next().is_none() {
+
+        let mut neighbors = self.top_layer_neighbors(position).peekable();
+        if neighbors.peek().is_none() {
             return false;
         }
-        !self
-            .top_layer_neighbors(position)
-            .any(|piece| color == piece.color().opposite_color())
+        !neighbors.any(|piece| color == piece.color().opposite_color())
     }
 
     pub fn negative_space(&self) -> impl Iterator<Item = Position> + '_ {

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -529,12 +529,8 @@ impl Board {
             return true;
         }
         // Spawn candidates must border one of our top pieces, so avoid scanning the full board.
-        self.positions.iter().flatten().any(|pos| {
-            if !self
-                .top_piece(*pos)
-                .map(|piece| piece.is_color(color))
-                .unwrap_or(false)
-            {
+        self.top_pieces().any(|(piece, pos)| {
+            if !piece.is_color(color) {
                 return false;
             }
             pos.positions_around().any(|target| {
@@ -547,17 +543,14 @@ impl Board {
     }
 
     fn has_board_action(&self, color: Color) -> bool {
-        for pos in self.positions.iter().flatten() {
-            let Some(piece) = self.top_piece(*pos) else {
-                continue;
-            };
-            if !piece.is_color(color) || self.last_moved == Some((piece, *pos)) {
+        for (piece, pos) in self.top_pieces() {
+            if !piece.is_color(color) || self.last_moved == Some((piece, pos)) {
                 continue;
             }
-            if !self.is_pinned(piece) && Bug::has_move(*pos, self) {
+            if !self.is_pinned(piece) && Bug::has_move(pos, self) {
                 return true;
             }
-            if Bug::has_available_ability(*pos, self) {
+            if Bug::has_available_ability(pos, self) {
                 return true;
             }
         }
@@ -863,25 +856,17 @@ impl Board {
         if !self.queen_played(color) {
             return moves;
         }
-        for pos in self.positions.iter().flatten() {
-            if let Some(piece) = self.top_piece(*pos) {
-                if piece.is_color(color) {
-                    // let's make sure pieces that were just moved cannot be moved again
-                    if let Some(last_moved) = self.last_moved {
-                        if last_moved == (piece, *pos) {
-                            // now we skip it
-                            continue;
-                        }
-                    }
-                    for (start_pos, mut target_positions) in Bug::available_moves(*pos, self) {
-                        if let Some(piece) = self.top_piece(start_pos) {
-                            if !target_positions.is_empty() {
-                                moves
-                                    .entry((piece, start_pos))
-                                    .or_default()
-                                    .append(&mut target_positions);
-                            }
-                        }
+        for (piece, pos) in self.top_pieces() {
+            if !piece.is_color(color) || self.last_moved == Some((piece, pos)) {
+                continue;
+            }
+            for (start_pos, mut target_positions) in Bug::available_moves(pos, self) {
+                if let Some(piece) = self.top_piece(start_pos) {
+                    if !target_positions.is_empty() {
+                        moves
+                            .entry((piece, start_pos))
+                            .or_default()
+                            .append(&mut target_positions);
                     }
                 }
             }
@@ -1024,21 +1009,27 @@ impl Board {
         res
     }
 
-    pub fn all_taken_positions(&self) -> impl Iterator<Item = Position> {
-        // TODO this does not uniq!
-        self.positions.into_iter().flatten()
+    pub fn all_taken_positions(&self) -> impl Iterator<Item = Position> + '_ {
+        self.top_pieces().map(|(_, position)| position)
+    }
+
+    fn top_pieces(&self) -> impl Iterator<Item = (Piece, Position)> + '_ {
+        self.positions
+            .iter()
+            .enumerate()
+            .filter_map(|(offset, maybe_position)| {
+                let position = (*maybe_position)?;
+                let piece = self.offset_to_piece(offset);
+                (self.top_piece(position) == Some(piece)).then_some((piece, position))
+            })
     }
 
     pub fn center_coordinates(&self) -> Position {
-        let positions = self.all_taken_positions().collect::<Vec<_>>();
-        //center won't shift much if any in the first few moves
-        if positions.len() < 8 {
-            return Position::initial_spawn_position();
-        }
-
-        let (q_min, q_max, r_min, r_max) = positions.iter().fold(
+        let mut positions = 0;
+        let (q_min, q_max, r_min, r_max) = self.all_taken_positions().fold(
             (i32::MAX, i32::MIN, i32::MAX, i32::MIN),
             |(q_min, q_max, r_min, r_max), pos| {
+                positions += 1;
                 (
                     q_min.min(pos.q),
                     q_max.max(pos.q),
@@ -1047,6 +1038,11 @@ impl Board {
                 )
             },
         );
+        //center won't shift much if any in the first few moves
+        if positions < 8 {
+            return Position::initial_spawn_position();
+        }
+
         //TODO: Some look centered with q + 1 some without it, figure out something
         Position {
             q: q_min + ((q_max - q_min) / 2),
@@ -1182,19 +1178,21 @@ impl Board {
             return None;
         }
 
-        let top_left =
-            self.all_taken_positions()
-                .fold(Position::new(BOARD_SIZE, BOARD_SIZE), |acc, pos| Position {
-                    q: acc.q.min(pos.q),
-                    r: acc.r.min(pos.r),
-                });
-
-        let bottom_right = self
-            .all_taken_positions()
-            .fold(Position::new(0, 0), |acc, pos| Position {
-                q: acc.q.max(pos.q),
-                r: acc.r.max(pos.r),
-            });
+        let (top_left, bottom_right) = self.all_taken_positions().fold(
+            (Position::new(BOARD_SIZE, BOARD_SIZE), Position::new(0, 0)),
+            |(top_left, bottom_right), pos| {
+                (
+                    Position {
+                        q: top_left.q.min(pos.q),
+                        r: top_left.r.min(pos.r),
+                    },
+                    Position {
+                        q: bottom_right.q.max(pos.q),
+                        r: bottom_right.r.max(pos.r),
+                    },
+                )
+            },
+        );
 
         Some(Bounds {
             top_left,

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -492,11 +492,74 @@ impl Board {
     }
 
     pub fn is_shutout(&self, color: Color, game_type: GameType) -> bool {
-        if let GameResult::Unknown = self.game_result() {
-            return self.moves(color).is_empty()
-                && (self.spawnable_positions(color).next().is_none()
-                    || self.reserve(color, game_type).is_empty());
-        };
+        if !matches!(self.game_result(), GameResult::Unknown) {
+            return false;
+        }
+        if self.played < 3 || !self.queen_played(color) {
+            return false;
+        }
+        if self.can_spawn_from_reserve(color, game_type) {
+            return false;
+        }
+        !self.has_board_action(color)
+    }
+
+    fn can_spawn_from_reserve(&self, color: Color, game_type: GameType) -> bool {
+        if self.played == game_type.max_played() {
+            return false;
+        }
+        self.has_reserve_piece(color, game_type) && self.has_spawnable_position(color)
+    }
+
+    fn has_reserve_piece(&self, color: Color, game_type: GameType) -> bool {
+        let start = 24 * color as usize;
+        let end = 24 + start;
+        self.positions[start..end]
+            .iter()
+            .enumerate()
+            .any(|(i, maybe_pos)| {
+                let offset = i + start;
+                maybe_pos.is_none() && self.offset_represents_piece(offset, game_type)
+            })
+    }
+
+    fn has_spawnable_position(&self, color: Color) -> bool {
+        if self.played < 2 {
+            return true;
+        }
+        // Spawn candidates must border one of our top pieces, so avoid scanning the full board.
+        self.positions.iter().flatten().any(|pos| {
+            if !self
+                .top_piece(*pos)
+                .map(|piece| piece.is_color(color))
+                .unwrap_or(false)
+            {
+                return false;
+            }
+            pos.positions_around().any(|target| {
+                !self.occupied(target)
+                    && !self
+                        .top_layer_neighbors(target)
+                        .any(|piece| color == piece.color().opposite_color())
+            })
+        })
+    }
+
+    fn has_board_action(&self, color: Color) -> bool {
+        for pos in self.positions.iter().flatten() {
+            let Some(piece) = self.top_piece(*pos) else {
+                continue;
+            };
+            if !piece.is_color(color) || self.last_moved == Some((piece, *pos)) {
+                continue;
+            }
+            if !self.is_pinned(piece) && Bug::has_move(*pos, self) {
+                return true;
+            }
+            if Bug::has_available_ability(*pos, self) {
+                return true;
+            }
+        }
         false
     }
 
@@ -620,6 +683,10 @@ impl Board {
         let bug = (offset as u8 - color * 24) / 3;
         let order = (offset as u8 + 1 - bug * 3 - color * 24) as usize;
         Piece::new_from(Bug::from(bug), Color::from(color), order)
+    }
+
+    fn offset_represents_piece(&self, offset: usize, game_type: GameType) -> bool {
+        self.offset_to_piece(offset).bug().count(game_type) > offset % 3
     }
 
     pub fn is_pinned(&self, piece: Piece) -> bool {
@@ -919,14 +986,12 @@ impl Board {
         let mut res = HashMap::<Bug, Vec<String>>::new();
         let start = 24 * color as usize;
         let end = 24 + start;
-        let bugs_for_game_type = Bug::bugs_count(game_type);
         for (i, maybe_pos) in self.positions[start..end].iter().enumerate() {
             if maybe_pos.is_none() {
-                let piece = self.offset_to_piece(i + 24 * color as usize);
-                if let Some(number_of_bugs) = bugs_for_game_type.get(&piece.bug()) {
-                    if (*number_of_bugs as usize) > (i % 3) {
-                        res.entry(piece.bug()).or_default().push(piece.to_string());
-                    }
+                let offset = i + start;
+                if self.offset_represents_piece(offset, game_type) {
+                    let piece = self.offset_to_piece(offset);
+                    res.entry(piece.bug()).or_default().push(piece.to_string());
                 }
             }
         }
@@ -971,12 +1036,10 @@ impl Board {
         if self.occupied(position) {
             return false;
         }
-        // TODO maybe hand in state.turn and get rid of this
-        let number_of_positions = self.positions.into_iter().flatten().count();
-        if number_of_positions == 0 {
+        if self.played == 0 {
             return position == Position::initial_spawn_position();
         }
-        if number_of_positions == 1 {
+        if self.played == 1 {
             return self.is_negative_space(position);
         }
         // connected to the hive
@@ -1141,7 +1204,50 @@ impl fmt::Display for Board {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{history::History, state::State};
     use std::collections::HashSet;
+
+    #[test]
+    fn tests_action_existence_matches_full_generation_for_pass_games() {
+        for file in [
+            "./test_pgns/valid/base_with_pass.pgn",
+            "./test_pgns/valid/m_with_pass.pgn",
+            "./test_pgns/valid/pass.pgn",
+            "./test_pgns/valid/pass2.pgn",
+        ] {
+            let history = History::from_filepath(file.into()).expect("valid history");
+            let tournament = !history.moves.iter().take(2).any(|(piece, _)| {
+                piece
+                    .parse::<Piece>()
+                    .map(|piece| piece.bug() == Bug::Queen)
+                    .unwrap_or(false)
+            });
+            let mut state = State::new(history.game_type, tournament);
+            for (piece, position) in history.moves.iter() {
+                let full_generation_has_legal_action =
+                    matches!(state.board.game_result(), GameResult::Unknown)
+                        && (!state.board.moves(state.turn_color).is_empty()
+                            || (state
+                                .board
+                                .spawnable_positions(state.turn_color)
+                                .next()
+                                .is_some()
+                                && !state
+                                    .board
+                                    .reserve(state.turn_color, state.game_type)
+                                    .is_empty()));
+                assert_eq!(
+                    state.board.is_shutout(state.turn_color, state.game_type),
+                    !full_generation_has_legal_action,
+                    "{file} turn {}",
+                    state.turn
+                );
+                state
+                    .play_turn_from_history(piece, position)
+                    .unwrap_or_else(|err| panic!("{file} turn {}: {err}", state.turn));
+            }
+        }
+    }
 
     #[test]
     fn tests_positions_around() {

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -193,35 +193,60 @@ impl Bug {
                 .top_piece(position)
                 .expect("There must be something at this position"),
         ) {
-            let positions = match board.top_bug(position) {
-                Some(Bug::Ant) => Bug::ant_moves(position, board),
-                Some(Bug::Beetle) => Bug::beetle_moves(position, board),
-                Some(Bug::Grasshopper) => Bug::grasshopper_moves(position, board),
-                Some(Bug::Ladybug) => Bug::ladybug_moves(position, board),
-                Some(Bug::Mosquito) => Bug::mosquito_moves(position, board),
-                Some(Bug::Pillbug) => Bug::pillbug_moves(position, board).collect(),
-                Some(Bug::Queen) => Bug::queen_moves(position, board).collect(),
-                Some(Bug::Spider) => Bug::spider_moves(position, board),
-                None => Vec::new(),
-            };
-            moves.insert(position, positions);
+            moves.insert(position, Bug::normal_moves(position, board));
         }
         moves.extend(Bug::available_abilities(position, board));
         moves
+    }
+
+    pub fn normal_moves(position: Position, board: &Board) -> Vec<Position> {
+        match board.top_bug(position) {
+            Some(Bug::Ant) => Bug::ant_moves(position, board),
+            Some(Bug::Beetle) => Bug::beetle_moves(position, board),
+            Some(Bug::Grasshopper) => Bug::grasshopper_moves(position, board),
+            Some(Bug::Ladybug) => Bug::ladybug_moves(position, board),
+            Some(Bug::Mosquito) => Bug::mosquito_moves(position, board),
+            Some(Bug::Pillbug) => Bug::pillbug_moves(position, board).collect(),
+            Some(Bug::Queen) => Bug::queen_moves(position, board).collect(),
+            Some(Bug::Spider) => Bug::spider_moves(position, board),
+            None => Vec::new(),
+        }
     }
 
     pub fn available_abilities(
         position: Position,
         board: &Board,
     ) -> HashMap<Position, Vec<Position>> {
+        if Bug::has_pillbug_throw(position, board) {
+            return Bug::pillbug_throw(position, board);
+        }
+        HashMap::default()
+    }
+
+    pub fn can_throw(
+        ability_position: Position,
+        thrown_position: Position,
+        target_position: Position,
+        board: &Board,
+    ) -> bool {
+        if !Bug::has_pillbug_throw(ability_position, board) {
+            return false;
+        }
+        if !Bug::pillbug_throw_targets(ability_position, board).any(|pos| pos == target_position) {
+            return false;
+        }
+        Bug::pillbug_throw_sources(ability_position, board).any(|pos| pos == thrown_position)
+    }
+
+    fn has_pillbug_throw(position: Position, board: &Board) -> bool {
         match board.top_bug(position) {
-            Some(Bug::Pillbug) => Bug::pillbug_throw(position, board),
+            Some(Bug::Pillbug) => true,
             Some(Bug::Mosquito)
                 if board.level(position) == 1 && board.neighbor_is_a(position, Bug::Pillbug) =>
             {
-                Bug::pillbug_throw(position, board)
+                true
             }
-            _ => HashMap::default(),
+            _ => false,
         }
     }
 
@@ -388,19 +413,32 @@ impl Bug {
         Bug::crawl(position, board)
     }
 
+    fn pillbug_throw_targets(
+        position: Position,
+        board: &Board,
+    ) -> impl Iterator<Item = Position> + '_ {
+        board
+            .positions_available_around(position)
+            .filter(move |pos| !board.gated(2, position, *pos))
+    }
+
+    fn pillbug_throw_sources(
+        position: Position,
+        board: &Board,
+    ) -> impl Iterator<Item = Position> + '_ {
+        board.positions_taken_around(position).filter_map(move |p| {
+            let piece = board.top_piece(p)?;
+            (!board.is_pinned(piece) && !board.gated(2, p, position) && board.level(p) <= 1)
+                .then_some(p)
+        })
+    }
+
     fn pillbug_throw(position: Position, board: &Board) -> HashMap<Position, Vec<Position>> {
         let mut moves = HashMap::default();
         // get all the positions the pillbug can throw a bug to
-        let to = board
-            .positions_available_around(position)
-            .filter(|pos| !board.gated(2, position, *pos))
-            .collect::<Vec<Position>>();
+        let to = Bug::pillbug_throw_targets(position, board).collect::<Vec<Position>>();
         // get bugs around the pillbug that aren't pinned
-        for pos in board.positions_taken_around(position).filter(|p| {
-            !board.is_pinned(board.top_piece(*p).unwrap())
-                && !board.gated(2, *p, position)
-                && board.level(*p) <= 1
-        }) {
+        for pos in Bug::pillbug_throw_sources(position, board) {
             moves.insert(pos, to.clone());
         }
         moves
@@ -454,8 +492,16 @@ mod tests {
             true,
         );
         let moves = Bug::available_moves(Position::new(0, 0), &board);
+        assert_eq!(
+            moves.get(&Position::new(0, 0)).unwrap(),
+            &Bug::normal_moves(Position::new(0, 0), &board)
+        );
         assert_eq!(moves.get(&Position::new(0, 0)).unwrap().len(), 2);
         let moves = Bug::available_moves(Position::new(1, 0), &board);
+        assert_eq!(
+            moves.get(&Position::new(1, 0)).unwrap(),
+            &Bug::normal_moves(Position::new(1, 0), &board)
+        );
         assert_eq!(moves.get(&Position::new(1, 0)).unwrap().len(), 6);
     }
 
@@ -473,9 +519,39 @@ mod tests {
             true,
         );
         let positions = Bug::available_abilities(Position::new(0, 0), &board);
-        assert_eq!(positions.get(&Position::new(1, 0)).unwrap().len(), 5);
+        let targets = positions.get(&Position::new(1, 0)).unwrap();
+        assert_eq!(targets.len(), 5);
+        for target in targets {
+            assert!(Bug::can_throw(
+                Position::new(0, 0),
+                Position::new(1, 0),
+                *target,
+                &board
+            ));
+        }
+        assert!(!Bug::can_throw(
+            Position::new(0, 0),
+            Position::new(1, 0),
+            Position::new(0, 0),
+            &board
+        ));
         let positions = Bug::available_abilities(Position::new(1, 0), &board);
-        assert_eq!(positions.get(&Position::new(0, 0)).unwrap().len(), 5);
+        let targets = positions.get(&Position::new(0, 0)).unwrap();
+        assert_eq!(targets.len(), 5);
+        for target in targets {
+            assert!(Bug::can_throw(
+                Position::new(1, 0),
+                Position::new(0, 0),
+                *target,
+                &board
+            ));
+        }
+        assert!(!Bug::can_throw(
+            Position::new(1, 0),
+            Position::new(0, 0),
+            Position::new(1, 0),
+            &board
+        ));
     }
 
     #[test]

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -1,5 +1,5 @@
 use crate::{
-    board::Board,
+    board::{Board, BOARD_SIZE},
     game_error::GameError,
     game_type::GameType,
     mid_move_board::MidMoveBoard,
@@ -274,10 +274,36 @@ impl Bug {
         if !Bug::has_pillbug_throw(ability_position, board) {
             return false;
         }
-        if !Bug::pillbug_throw_targets(ability_position, board).any(|pos| pos == target_position) {
+        Bug::can_throw_piece_to(ability_position, thrown_position, target_position, board)
+    }
+
+    pub(crate) fn can_throw_piece_to(
+        ability_position: Position,
+        piece_position: Position,
+        destination: Position,
+        board: &Board,
+    ) -> bool {
+        if !Bug::is_canonical_position(piece_position) || !Bug::is_canonical_position(destination) {
             return false;
         }
-        Bug::pillbug_throw_sources(ability_position, board).any(|pos| pos == thrown_position)
+
+        let destination_is_available = ability_position.is_neighbor(destination)
+            && !board.occupied(destination)
+            && !board.gated(2, ability_position, destination);
+        if !destination_is_available {
+            return false;
+        }
+        if !ability_position.is_neighbor(piece_position) || board.level(piece_position) > 1 {
+            return false;
+        }
+        let Some(piece) = board.top_piece(piece_position) else {
+            return false;
+        };
+        !board.is_pinned(piece) && !board.gated(2, piece_position, ability_position)
+    }
+
+    fn is_canonical_position(position: Position) -> bool {
+        (0..BOARD_SIZE).contains(&position.q) && (0..BOARD_SIZE).contains(&position.r)
     }
 
     fn has_pillbug_throw(position: Position, board: &Board) -> bool {
@@ -611,7 +637,7 @@ impl Bug {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{board::BOARD_SIZE, color::Color, piece::Piece};
+    use crate::{color::Color, piece::Piece};
 
     fn assert_lazy_predicates_match_collected(board: &Board) {
         let mut checked_positions = Vec::new();
@@ -804,6 +830,79 @@ mod tests {
             Position::new(1, 0),
             Position::new(0, 0),
             Position::new(1, 0),
+            &board
+        ));
+        assert!(!Bug::can_throw(
+            Position::new(0, 0),
+            Position::new(1, 0),
+            Position::new(2, 0),
+            &board
+        ));
+
+        assert!(!Bug::can_throw(
+            Position::new(0, 0),
+            Position::new(2, 0),
+            Position::new(0, 1),
+            &board
+        ));
+    }
+
+    #[test]
+    fn tests_can_throw_rejects_non_canonical_positions() {
+        let mut board = Board::new();
+        board.insert(
+            Position::new(0, 0),
+            Piece::new_from(Bug::Pillbug, Color::White, 0),
+            true,
+        );
+        board.insert(
+            Position::new(1, 0),
+            Piece::new_from(Bug::Mosquito, Color::Black, 0),
+            true,
+        );
+        assert!(!Bug::can_throw(
+            Position::new(0, 0),
+            Position::new(1, 0),
+            Position { q: -1, r: 0 },
+            &board
+        ));
+
+        let mut board = Board::new();
+        board.insert(
+            Position::new(0, 0),
+            Piece::new_from(Bug::Pillbug, Color::White, 0),
+            true,
+        );
+        board.insert(
+            Position::new(-1, 0),
+            Piece::new_from(Bug::Mosquito, Color::Black, 0),
+            true,
+        );
+        assert!(!Bug::can_throw(
+            Position::new(0, 0),
+            Position { q: -1, r: 0 },
+            Position::new(0, 1),
+            &board
+        ));
+
+        let mut board = Board::new();
+        board.insert(
+            Position::new(-1, 0),
+            Piece::new_from(Bug::Pillbug, Color::White, 0),
+            true,
+        );
+        board.insert(
+            Position::new(0, 0),
+            Piece::new_from(Bug::Mosquito, Color::Black, 0),
+            true,
+        );
+        assert!(!Bug::can_throw(
+            Position::new(-1, 0),
+            Position::new(0, 0),
+            Position {
+                q: BOARD_SIZE,
+                r: 0
+            },
             &board
         ));
     }

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -231,7 +231,7 @@ impl Bug {
     ) -> impl Iterator<Item = Position> + 'a {
         position.positions_around().filter(move |pos| {
             let (pos1, pos2) = position.common_adjacent_positions(*pos);
-            (!board.get(pos1).is_empty() || !board.get(pos2).is_empty())
+            (board.occupied(pos1) || board.occupied(pos2))
                 && board.is_negative_space(*pos)
                 && !board.gated(1, position, *pos)
         })

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -239,15 +239,13 @@ impl Bug {
 
     fn crawl(position: Position, board: &Board) -> impl Iterator<Item = Position> + '_ {
         board.positions_taken_around(position).flat_map(move |pos| {
-            let mut positions = vec![];
             let (pos1, pos2) = position.common_adjacent_positions(pos);
-            if !board.gated(1, position, pos1) && !board.occupied(pos1) {
-                positions.push(pos1);
-            }
-            if !board.gated(1, position, pos2) && !board.occupied(pos2) {
-                positions.push(pos2);
-            }
-            positions
+            [
+                (!board.gated(1, position, pos1) && !board.occupied(pos1)).then_some(pos1),
+                (!board.gated(1, position, pos2) && !board.occupied(pos2)).then_some(pos2),
+            ]
+            .into_iter()
+            .flatten()
         })
     }
 

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -343,9 +343,11 @@ impl Bug {
     }
 
     fn climb(position: Position, board: &Board) -> impl Iterator<Item = Position> + '_ {
-        board
-            .positions_taken_around(position)
-            .filter(move |pos| !board.gated(board.level(*pos) + 1, position, *pos))
+        let source_level = board.level(position);
+        board.positions_taken_around(position).filter(move |pos| {
+            let target_level = board.level(*pos);
+            target_level >= source_level && !board.gated(target_level + 1, position, *pos)
+        })
     }
 
     fn descend(position: Position, board: &Board) -> impl Iterator<Item = Position> + '_ {
@@ -418,26 +420,15 @@ impl Bug {
         board: &Board,
         keep_scanning: &mut impl FnMut(Position) -> bool,
     ) -> bool {
-        let mut positions = Vec::new();
-        for pos in Bug::climb(position, board) {
-            if !Bug::scan_unique_target_while(&mut positions, pos, keep_scanning) {
-                return false;
-            }
+        if !Bug::scan_targets_while(Bug::climb(position, board), keep_scanning) {
+            return false;
         }
+
         if board.level(position) == 1 {
-            for pos in Bug::crawl(position, board) {
-                if !Bug::scan_unique_target_while(&mut positions, pos, keep_scanning) {
-                    return false;
-                }
-            }
+            Bug::scan_targets_while(Bug::crawl(position, board), keep_scanning)
         } else {
-            for pos in Bug::descend(position, board) {
-                if !Bug::scan_unique_target_while(&mut positions, pos, keep_scanning) {
-                    return false;
-                }
-            }
+            Bug::scan_targets_while(Bug::descend(position, board), keep_scanning)
         }
-        true
     }
 
     pub fn grasshopper_moves(position: Position, board: &Board) -> Vec<Position> {
@@ -578,12 +569,14 @@ impl Bug {
         board: &Board,
         keep_scanning: &mut impl FnMut(Position) -> bool,
     ) -> bool {
-        for pos in Bug::crawl(position, board) {
-            if !keep_scanning(pos) {
-                return false;
-            }
-        }
-        true
+        Bug::scan_targets_while(Bug::crawl(position, board), keep_scanning)
+    }
+
+    fn scan_targets_while(
+        targets: impl IntoIterator<Item = Position>,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
+        targets.into_iter().all(keep_scanning)
     }
 
     fn scan_unique_target_while(
@@ -607,8 +600,6 @@ impl Bug {
             res.push(pos);
             true
         });
-        res.sort();
-        res.dedup();
         res
     }
 
@@ -1494,6 +1485,41 @@ mod tests {
         }
         board.remove(Position::new(1, 0));
         assert_eq!(Bug::beetle_moves(Position::new(0, 0), &board).len(), 5);
+    }
+
+    #[test]
+    fn beetle_moves_partition_stack_targets_without_duplicates() {
+        let source = Position::new(0, 0);
+        let lower_stack = Position::new(0, -1);
+        let equal_stack = Position::new(1, -1);
+
+        let mut board = Board::new();
+        board.insert(source, Piece::new_from(Bug::Ant, Color::White, 1), true);
+        board.insert(source, Piece::new_from(Bug::Beetle, Color::White, 1), true);
+        board.insert(
+            lower_stack,
+            Piece::new_from(Bug::Queen, Color::Black, 0),
+            true,
+        );
+        board.insert(
+            equal_stack,
+            Piece::new_from(Bug::Ant, Color::Black, 1),
+            true,
+        );
+        board.insert(
+            equal_stack,
+            Piece::new_from(Bug::Beetle, Color::Black, 1),
+            true,
+        );
+
+        let moves = Bug::beetle_moves(source, &board);
+        let mut unique_moves = moves.clone();
+        unique_moves.sort();
+        unique_moves.dedup();
+
+        assert_eq!(moves.len(), unique_moves.len());
+        assert!(moves.contains(&lower_stack));
+        assert!(moves.contains(&equal_stack));
     }
 
     #[test]

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -137,43 +137,24 @@ impl Bug {
         .to_string()
     }
 
-    pub fn bugs_count(game_type: GameType) -> HashMap<Bug, i8> {
-        let mut bugs = HashMap::new();
-        bugs.insert(Bug::Ant, 3);
-        bugs.insert(Bug::Beetle, 2);
-        bugs.insert(Bug::Grasshopper, 3);
-        bugs.insert(Bug::Queen, 1);
-        bugs.insert(Bug::Spider, 2);
-        match game_type {
-            GameType::Base => {}
-            GameType::M => {
-                bugs.insert(Bug::Mosquito, 1);
-            }
-            GameType::L => {
-                bugs.insert(Bug::Ladybug, 1);
-            }
-            GameType::P => {
-                bugs.insert(Bug::Pillbug, 1);
-            }
-            GameType::ML => {
-                bugs.insert(Bug::Mosquito, 1);
-                bugs.insert(Bug::Ladybug, 1);
-            }
-            GameType::MP => {
-                bugs.insert(Bug::Mosquito, 1);
-                bugs.insert(Bug::Pillbug, 1);
-            }
-            GameType::LP => {
-                bugs.insert(Bug::Ladybug, 1);
-                bugs.insert(Bug::Pillbug, 1);
-            }
-            GameType::MLP => {
-                bugs.insert(Bug::Mosquito, 1);
-                bugs.insert(Bug::Ladybug, 1);
-                bugs.insert(Bug::Pillbug, 1);
-            }
+    pub(crate) fn count(self, game_type: GameType) -> usize {
+        match self {
+            Bug::Ant | Bug::Grasshopper => 3,
+            Bug::Beetle | Bug::Spider => 2,
+            Bug::Queen => 1,
+            Bug::Ladybug => usize::from(matches!(
+                game_type,
+                GameType::L | GameType::ML | GameType::LP | GameType::MLP
+            )),
+            Bug::Mosquito => usize::from(matches!(
+                game_type,
+                GameType::M | GameType::ML | GameType::MP | GameType::MLP
+            )),
+            Bug::Pillbug => usize::from(matches!(
+                game_type,
+                GameType::P | GameType::LP | GameType::MP | GameType::MLP
+            )),
         }
-        bugs
     }
 
     pub fn has_order(&self) -> bool {
@@ -213,6 +194,20 @@ impl Bug {
         }
     }
 
+    pub(crate) fn has_move(position: Position, board: &Board) -> bool {
+        match board.top_bug(position) {
+            Some(Bug::Ant) => Bug::has_ant_move(position, board),
+            Some(Bug::Beetle) => Bug::has_beetle_move(position, board),
+            Some(Bug::Grasshopper) => Bug::has_grasshopper_move(position, board),
+            Some(Bug::Ladybug) => Bug::has_ladybug_move(position, board),
+            Some(Bug::Mosquito) => Bug::has_mosquito_move(position, board),
+            Some(Bug::Pillbug) => Bug::has_pillbug_move(position, board),
+            Some(Bug::Queen) => Bug::has_queen_move(position, board),
+            Some(Bug::Spider) => Bug::has_spider_move(position, board),
+            None => false,
+        }
+    }
+
     pub fn available_abilities(
         position: Position,
         board: &Board,
@@ -221,6 +216,21 @@ impl Bug {
             return Bug::pillbug_throw(position, board);
         }
         HashMap::default()
+    }
+
+    pub(crate) fn has_available_ability(position: Position, board: &Board) -> bool {
+        if !Bug::has_pillbug_throw(position, board) {
+            return false;
+        }
+        if Bug::pillbug_throw_targets(position, board).next().is_none() {
+            return false;
+        }
+        Bug::pillbug_throw_sources(position, board).any(|pos| {
+            let Some(piece) = board.top_piece(pos) else {
+                return false;
+            };
+            board.last_moved != Some((piece, pos))
+        })
     }
 
     pub fn can_throw(
@@ -274,6 +284,10 @@ impl Bug {
         })
     }
 
+    fn has_crawl_move(position: Position, board: &Board) -> bool {
+        Bug::crawl(position, board).next().is_some()
+    }
+
     fn climb(position: Position, board: &Board) -> impl Iterator<Item = Position> + '_ {
         board
             .positions_taken_around(position)
@@ -321,6 +335,10 @@ impl Bug {
         }
     }
 
+    fn has_ant_move(position: Position, board: &Board) -> bool {
+        Bug::has_crawl_move(position, board)
+    }
+
     pub fn beetle_moves(position: Position, board: &Board) -> Vec<Position> {
         let mut positions = Vec::new();
         for pos in Bug::climb(position, board) {
@@ -342,6 +360,17 @@ impl Bug {
         positions
     }
 
+    fn has_beetle_move(position: Position, board: &Board) -> bool {
+        if Bug::climb(position, board).next().is_some() {
+            return true;
+        }
+        if board.level(position) == 1 {
+            Bug::has_crawl_move(position, board)
+        } else {
+            Bug::descend(position, board).next().is_some()
+        }
+    }
+
     pub fn grasshopper_moves(position: Position, board: &Board) -> Vec<Position> {
         // get the directions of the grasshopper's neighbors
         let mut positions = vec![];
@@ -359,6 +388,10 @@ impl Bug {
             positions.push(cur_pos.to(dir));
         }
         positions
+    }
+
+    fn has_grasshopper_move(position: Position, board: &Board) -> bool {
+        board.positions_taken_around(position).next().is_some()
     }
 
     fn ladybug_moves(position: Position, board: &Board) -> Vec<Position> {
@@ -387,6 +420,26 @@ impl Bug {
         third.iter().cloned().collect()
     }
 
+    fn has_ladybug_move(position: Position, board: &Board) -> bool {
+        for first_pos in Bug::climb(position, board) {
+            let current_height = board.level(first_pos) + 1;
+            for second_pos in board.positions_taken_around(first_pos).filter(|pos| {
+                *pos != position
+                    && !board.gated(current_height.max(board.level(*pos) + 1), first_pos, *pos)
+            }) {
+                if board
+                    .positions_available_around(second_pos)
+                    .any(|third_pos| {
+                        !board.gated(board.level(second_pos) + 1, second_pos, third_pos)
+                    })
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     fn mosquito_moves(position: Position, board: &Board) -> Vec<Position> {
         if board.level(position) == 1 {
             board
@@ -409,8 +462,31 @@ impl Bug {
         }
     }
 
+    fn has_mosquito_move(position: Position, board: &Board) -> bool {
+        if board.level(position) == 1 {
+            board.neighbors(position).any(|pieces| {
+                match pieces.top_piece().expect("Could not get last piece").bug() {
+                    Bug::Ant => Bug::has_ant_move(position, board),
+                    Bug::Beetle => Bug::has_beetle_move(position, board),
+                    Bug::Grasshopper => Bug::has_grasshopper_move(position, board),
+                    Bug::Ladybug => Bug::has_ladybug_move(position, board),
+                    Bug::Mosquito => false,
+                    Bug::Pillbug => Bug::has_pillbug_move(position, board),
+                    Bug::Queen => Bug::has_queen_move(position, board),
+                    Bug::Spider => Bug::has_spider_move(position, board),
+                }
+            })
+        } else {
+            Bug::has_beetle_move(position, board)
+        }
+    }
+
     fn pillbug_moves(position: Position, board: &Board) -> impl Iterator<Item = Position> + '_ {
         Bug::crawl(position, board)
+    }
+
+    fn has_pillbug_move(position: Position, board: &Board) -> bool {
+        Bug::has_crawl_move(position, board)
     }
 
     fn pillbug_throw_targets(
@@ -448,6 +524,10 @@ impl Bug {
         Bug::crawl(position, board)
     }
 
+    fn has_queen_move(position: Position, board: &Board) -> bool {
+        Bug::has_crawl_move(position, board)
+    }
+
     fn spider_moves(position: Position, board: &Board) -> Vec<Position> {
         let board = MidMoveBoard::new(board, position);
         let mut res = Vec::new();
@@ -465,6 +545,20 @@ impl Bug {
         res.sort();
         res.dedup();
         res
+    }
+
+    fn has_spider_move(position: Position, board: &Board) -> bool {
+        let board = MidMoveBoard::new(board, position);
+        for pos1 in Bug::crawl_negative_space(position, &board) {
+            for pos2 in Bug::crawl_negative_space(pos1, &board).filter(|pos| *pos != position) {
+                if Bug::crawl_negative_space(pos2, &board)
+                    .any(|pos3| pos3 != position && pos3 != pos1)
+                {
+                    return true;
+                }
+            }
+        }
+        false
     }
 }
 

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -7,11 +7,7 @@ use crate::{
     torus_array::TorusArray,
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    str::FromStr,
-};
+use std::{collections::HashMap, fmt, str::FromStr};
 
 #[derive(Hash, Eq, PartialEq, Clone, Copy, Serialize, Deserialize, Debug)]
 #[repr(u8)]
@@ -195,16 +191,52 @@ impl Bug {
     }
 
     pub(crate) fn has_move(position: Position, board: &Board) -> bool {
+        Bug::has_normal_move_matching(position, board, |_| true)
+    }
+
+    pub(crate) fn has_target_move(position: Position, target: Position, board: &Board) -> bool {
+        Bug::has_normal_move_matching(position, board, |pos| pos == target)
+    }
+
+    fn has_normal_move_matching(
+        position: Position,
+        board: &Board,
+        mut predicate: impl FnMut(Position) -> bool,
+    ) -> bool {
+        !Bug::scan_normal_moves_while(position, board, &mut |target| !predicate(target))
+    }
+
+    /// Scans legal normal-move targets for the top bug at `position` while
+    /// `keep_scanning` returns true.
+    ///
+    /// Returns true only when all targets were scanned. Returns false when
+    /// `keep_scanning` stopped generation early.
+    fn scan_normal_moves_while(
+        position: Position,
+        board: &Board,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
         match board.top_bug(position) {
-            Some(Bug::Ant) => Bug::has_ant_move(position, board),
-            Some(Bug::Beetle) => Bug::has_beetle_move(position, board),
-            Some(Bug::Grasshopper) => Bug::has_grasshopper_move(position, board),
-            Some(Bug::Ladybug) => Bug::has_ladybug_move(position, board),
-            Some(Bug::Mosquito) => Bug::has_mosquito_move(position, board),
-            Some(Bug::Pillbug) => Bug::has_pillbug_move(position, board),
-            Some(Bug::Queen) => Bug::has_queen_move(position, board),
-            Some(Bug::Spider) => Bug::has_spider_move(position, board),
-            None => false,
+            Some(bug) => Bug::scan_moves_as_bug_while(bug, position, board, keep_scanning),
+            None => true,
+        }
+    }
+
+    fn scan_moves_as_bug_while(
+        bug: Bug,
+        position: Position,
+        board: &Board,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
+        match bug {
+            Bug::Ant => Bug::scan_ant_moves_while(position, board, keep_scanning),
+            Bug::Beetle => Bug::scan_beetle_moves_while(position, board, keep_scanning),
+            Bug::Grasshopper => Bug::scan_grasshopper_moves_while(position, board, keep_scanning),
+            Bug::Ladybug => Bug::scan_ladybug_moves_while(position, board, keep_scanning),
+            Bug::Mosquito => Bug::scan_mosquito_moves_while(position, board, keep_scanning),
+            Bug::Pillbug => Bug::scan_crawl_moves_while(position, board, keep_scanning),
+            Bug::Queen => Bug::scan_crawl_moves_while(position, board, keep_scanning),
+            Bug::Spider => Bug::scan_spider_moves_while(position, board, keep_scanning),
         }
     }
 
@@ -284,10 +316,6 @@ impl Bug {
         })
     }
 
-    fn has_crawl_move(position: Position, board: &Board) -> bool {
-        Bug::crawl(position, board).next().is_some()
-    }
-
     fn climb(position: Position, board: &Board) -> impl Iterator<Item = Position> + '_ {
         board
             .positions_taken_around(position)
@@ -302,191 +330,186 @@ impl Bug {
     }
 
     fn ant_moves(position: Position, board: &Board) -> Vec<Position> {
-        //                               found  explored
-        let mut state = TorusArray::new((false, false));
-        state.set(position, (true, true));
-        let board = MidMoveBoard::new(board, position);
         let mut found_pos = Vec::with_capacity(24);
-        let mut unexplored = Vec::with_capacity(24);
-        unexplored.push(position);
-        Bug::ant_rec(&mut state, &mut found_pos, &mut unexplored, &board);
+        Bug::scan_ant_moves_while(position, board, &mut |pos| {
+            found_pos.push(pos);
+            true
+        });
         found_pos
     }
 
-    fn ant_rec(
-        state: &mut TorusArray<(bool, bool)>,
-        found_pos: &mut Vec<Position>,
-        unexplored: &mut Vec<Position>,
-        board: &MidMoveBoard,
-    ) {
-        while let Some(position) = unexplored.pop() {
-            let (found, explored) = state.get(position);
-            if !found {
-                state.set(position, (true, *explored));
-                found_pos.push(position);
+    fn scan_ant_moves_while(
+        position: Position,
+        board: &Board,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
+        let board = MidMoveBoard::new(board, position);
+        let mut unexplored = None;
+        for pos in Bug::crawl_negative_space(position, &board) {
+            if !keep_scanning(pos) {
+                return false;
             }
-            for pos in Bug::crawl_negative_space(position, board) {
+            unexplored
+                .get_or_insert_with(|| Vec::with_capacity(24))
+                .push(pos);
+        }
+        let Some(mut unexplored) = unexplored else {
+            return true;
+        };
+
+        let mut state = TorusArray::new((false, false));
+        state.set(position, (true, true));
+        for pos in &unexplored {
+            state.set(*pos, (true, true));
+        }
+
+        while let Some(position) = unexplored.pop() {
+            for pos in Bug::crawl_negative_space(position, &board) {
                 let (found, explored) = state.get(pos);
                 if !explored && !found && board.is_negative_space(pos) {
-                    state.set(pos, (*found, true));
+                    if !keep_scanning(pos) {
+                        return false;
+                    }
+                    state.set(pos, (true, true));
                     unexplored.push(pos);
                 }
             }
         }
-    }
-
-    fn has_ant_move(position: Position, board: &Board) -> bool {
-        Bug::has_crawl_move(position, board)
+        true
     }
 
     pub fn beetle_moves(position: Position, board: &Board) -> Vec<Position> {
         let mut positions = Vec::new();
-        for pos in Bug::climb(position, board) {
+        Bug::scan_beetle_moves_while(position, board, &mut |pos| {
             positions.push(pos);
+            true
+        });
+        positions
+    }
+
+    fn scan_beetle_moves_while(
+        position: Position,
+        board: &Board,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
+        let mut positions = Vec::new();
+        for pos in Bug::climb(position, board) {
+            if !Bug::scan_unique_target_while(&mut positions, pos, keep_scanning) {
+                return false;
+            }
         }
         if board.level(position) == 1 {
             for pos in Bug::crawl(position, board) {
-                if !positions.contains(&pos) {
-                    positions.push(pos);
+                if !Bug::scan_unique_target_while(&mut positions, pos, keep_scanning) {
+                    return false;
                 }
             }
         } else {
             for pos in Bug::descend(position, board) {
-                if !positions.contains(&pos) {
-                    positions.push(pos);
+                if !Bug::scan_unique_target_while(&mut positions, pos, keep_scanning) {
+                    return false;
                 }
             }
         }
-        positions
-    }
-
-    fn has_beetle_move(position: Position, board: &Board) -> bool {
-        if Bug::climb(position, board).next().is_some() {
-            return true;
-        }
-        if board.level(position) == 1 {
-            Bug::has_crawl_move(position, board)
-        } else {
-            Bug::descend(position, board).next().is_some()
-        }
+        true
     }
 
     pub fn grasshopper_moves(position: Position, board: &Board) -> Vec<Position> {
-        // get the directions of the grasshopper's neighbors
-        let mut positions = vec![];
-        // move in the given direction
+        let mut positions = Vec::new();
+        Bug::scan_grasshopper_moves_while(position, board, &mut |pos| {
+            positions.push(pos);
+            true
+        });
+        positions
+    }
+
+    fn scan_grasshopper_moves_while(
+        position: Position,
+        board: &Board,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
         for dir in board
             .positions_taken_around(position)
             .map(|pos| position.direction(pos))
         {
             let mut cur_pos = position;
-            // until there is a free position
             while board.occupied(cur_pos.to(dir)) {
                 cur_pos = cur_pos.to(dir);
             }
-            // then add the free position
-            positions.push(cur_pos.to(dir));
+            if !keep_scanning(cur_pos.to(dir)) {
+                return false;
+            }
         }
-        positions
-    }
-
-    fn has_grasshopper_move(position: Position, board: &Board) -> bool {
-        board.positions_taken_around(position).next().is_some()
+        true
     }
 
     fn ladybug_moves(position: Position, board: &Board) -> Vec<Position> {
-        // find all adjacent bugs to climb on
-        let first = Bug::climb(position, board);
-        // stay on top of the hive by moving on to an adjacent occupied hex
-        let second: HashSet<Position> = first
-            .flat_map(|first_pos| {
-                let current_height = board.level(first_pos) + 1;
-                board.positions_taken_around(first_pos).filter(move |pos| {
-                    *pos != position
-                        && !board.gated(current_height.max(board.level(*pos) + 1), first_pos, *pos)
-                })
-            })
-            .collect::<HashSet<Position>>();
-        // then find available and ungated positions
-        let third: HashSet<Position> = second
-            .iter()
-            .flat_map(|pos| {
-                board
-                    .positions_available_around(*pos)
-                    .filter(|p| !board.gated(board.level(*pos) + 1, *pos, *p))
-                    .collect::<HashSet<Position>>()
-            })
-            .collect::<HashSet<Position>>();
-        third.iter().cloned().collect()
+        let mut positions = Vec::new();
+        Bug::scan_ladybug_moves_while(position, board, &mut |pos| {
+            positions.push(pos);
+            true
+        });
+        positions
     }
 
-    fn has_ladybug_move(position: Position, board: &Board) -> bool {
+    fn scan_ladybug_moves_while(
+        position: Position,
+        board: &Board,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
+        let mut positions = Vec::new();
         for first_pos in Bug::climb(position, board) {
             let current_height = board.level(first_pos) + 1;
             for second_pos in board.positions_taken_around(first_pos).filter(|pos| {
                 *pos != position
                     && !board.gated(current_height.max(board.level(*pos) + 1), first_pos, *pos)
             }) {
-                if board
+                for third_pos in board
                     .positions_available_around(second_pos)
-                    .any(|third_pos| {
-                        !board.gated(board.level(second_pos) + 1, second_pos, third_pos)
+                    .filter(|third_pos| {
+                        !board.gated(board.level(second_pos) + 1, second_pos, *third_pos)
                     })
                 {
-                    return true;
+                    if !Bug::scan_unique_target_while(&mut positions, third_pos, keep_scanning) {
+                        return false;
+                    }
                 }
             }
         }
-        false
+        true
     }
 
     fn mosquito_moves(position: Position, board: &Board) -> Vec<Position> {
-        if board.level(position) == 1 {
-            board
-                .neighbors(position)
-                .flat_map(|pieces| {
-                    match pieces.top_piece().expect("Could not get last piece").bug() {
-                        Bug::Ant => Bug::ant_moves(position, board),
-                        Bug::Beetle => Bug::beetle_moves(position, board),
-                        Bug::Grasshopper => Bug::grasshopper_moves(position, board),
-                        Bug::Ladybug => Bug::ladybug_moves(position, board),
-                        Bug::Mosquito => vec![],
-                        Bug::Pillbug => Bug::pillbug_moves(position, board).collect(),
-                        Bug::Queen => Bug::queen_moves(position, board).collect(),
-                        Bug::Spider => Bug::spider_moves(position, board),
-                    }
-                })
-                .collect()
-        } else {
-            Bug::beetle_moves(position, board)
-        }
+        let mut positions = Vec::new();
+        Bug::scan_mosquito_moves_while(position, board, &mut |pos| {
+            positions.push(pos);
+            true
+        });
+        positions
     }
 
-    fn has_mosquito_move(position: Position, board: &Board) -> bool {
+    fn scan_mosquito_moves_while(
+        position: Position,
+        board: &Board,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
         if board.level(position) == 1 {
-            board.neighbors(position).any(|pieces| {
-                match pieces.top_piece().expect("Could not get last piece").bug() {
-                    Bug::Ant => Bug::has_ant_move(position, board),
-                    Bug::Beetle => Bug::has_beetle_move(position, board),
-                    Bug::Grasshopper => Bug::has_grasshopper_move(position, board),
-                    Bug::Ladybug => Bug::has_ladybug_move(position, board),
-                    Bug::Mosquito => false,
-                    Bug::Pillbug => Bug::has_pillbug_move(position, board),
-                    Bug::Queen => Bug::has_queen_move(position, board),
-                    Bug::Spider => Bug::has_spider_move(position, board),
+            for pieces in board.neighbors(position) {
+                let bug = pieces.top_piece().expect("Could not get last piece").bug();
+                if bug != Bug::Mosquito
+                    && !Bug::scan_moves_as_bug_while(bug, position, board, keep_scanning)
+                {
+                    return false;
                 }
-            })
+            }
+            true
         } else {
-            Bug::has_beetle_move(position, board)
+            Bug::scan_beetle_moves_while(position, board, keep_scanning)
         }
     }
 
     fn pillbug_moves(position: Position, board: &Board) -> impl Iterator<Item = Position> + '_ {
         Bug::crawl(position, board)
-    }
-
-    fn has_pillbug_move(position: Position, board: &Board) -> bool {
-        Bug::has_crawl_move(position, board)
     }
 
     fn pillbug_throw_targets(
@@ -524,48 +547,185 @@ impl Bug {
         Bug::crawl(position, board)
     }
 
-    fn has_queen_move(position: Position, board: &Board) -> bool {
-        Bug::has_crawl_move(position, board)
+    fn scan_crawl_moves_while(
+        position: Position,
+        board: &Board,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
+        for pos in Bug::crawl(position, board) {
+            if !keep_scanning(pos) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn scan_unique_target_while(
+        visited_targets: &mut Vec<Position>,
+        target: Position,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
+        if visited_targets.contains(&target) {
+            return true;
+        }
+        if !keep_scanning(target) {
+            return false;
+        }
+        visited_targets.push(target);
+        true
     }
 
     fn spider_moves(position: Position, board: &Board) -> Vec<Position> {
-        let board = MidMoveBoard::new(board, position);
         let mut res = Vec::new();
-        for pos1 in Bug::crawl_negative_space(position, &board) {
-            for pos2 in Bug::crawl_negative_space(pos1, &board).filter(move |pos| *pos != position)
-            {
-                for pos3 in Bug::crawl_negative_space(pos2, &board).filter(move |pos| *pos != pos1)
-                {
-                    if pos3 != position {
-                        res.push(pos3);
-                    }
-                }
-            }
-        }
+        Bug::scan_spider_moves_while(position, board, &mut |pos| {
+            res.push(pos);
+            true
+        });
         res.sort();
         res.dedup();
         res
     }
 
-    fn has_spider_move(position: Position, board: &Board) -> bool {
+    fn scan_spider_moves_while(
+        position: Position,
+        board: &Board,
+        keep_scanning: &mut impl FnMut(Position) -> bool,
+    ) -> bool {
         let board = MidMoveBoard::new(board, position);
+        let mut positions = Vec::new();
         for pos1 in Bug::crawl_negative_space(position, &board) {
             for pos2 in Bug::crawl_negative_space(pos1, &board).filter(|pos| *pos != position) {
-                if Bug::crawl_negative_space(pos2, &board)
-                    .any(|pos3| pos3 != position && pos3 != pos1)
+                for pos3 in Bug::crawl_negative_space(pos2, &board)
+                    .filter(|pos3| *pos3 != position && *pos3 != pos1)
                 {
-                    return true;
+                    if !Bug::scan_unique_target_while(&mut positions, pos3, keep_scanning) {
+                        return false;
+                    }
                 }
             }
         }
-        false
+        true
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{color::Color, piece::Piece};
+    use crate::{board::BOARD_SIZE, color::Color, piece::Piece};
+
+    fn assert_lazy_predicates_match_collected(board: &Board) {
+        let mut checked_positions = Vec::new();
+        for position in board.positions.iter().flatten() {
+            if checked_positions.contains(position) {
+                continue;
+            }
+            checked_positions.push(*position);
+
+            let collected = Bug::normal_moves(*position, board);
+            assert_eq!(
+                Bug::has_move(*position, board),
+                !collected.is_empty(),
+                "has_move disagrees with normal_moves at {position}"
+            );
+
+            for target in &collected {
+                assert!(
+                    Bug::has_target_move(*position, *target, board),
+                    "has_target_move missed collected move from {position} to {target}"
+                );
+            }
+
+            for q in 0..BOARD_SIZE {
+                for r in 0..BOARD_SIZE {
+                    let target = Position::new(q, r);
+                    assert_eq!(
+                        Bug::has_target_move(*position, target, board),
+                        collected.contains(&target),
+                        "has_target_move disagrees with normal_moves from {position} to {target}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn tests_lazy_predicates_match_collected_moves() {
+        let mut board = Board::new();
+        board.insert(
+            Position::new(0, 0),
+            Piece::new_from(Bug::Pillbug, Color::White, 0),
+            true,
+        );
+        board.insert(
+            Position::new(1, 0),
+            Piece::new_from(Bug::Mosquito, Color::Black, 0),
+            true,
+        );
+        assert_lazy_predicates_match_collected(&board);
+
+        let mut board = Board::new();
+        board.insert(
+            Position::new(0, 0),
+            Piece::new_from(Bug::Spider, Color::White, 1),
+            true,
+        );
+        board.insert(
+            Position::new(1, 0),
+            Piece::new_from(Bug::Ant, Color::Black, 1),
+            true,
+        );
+        assert_lazy_predicates_match_collected(&board);
+
+        let mut board = Board::new();
+        board.insert(
+            Position::new(0, 0),
+            Piece::new_from(Bug::Ladybug, Color::White, 0),
+            true,
+        );
+        for (i, pos) in Position::new(0, 0).positions_around().enumerate() {
+            board.insert(
+                pos,
+                Piece::new_from(Bug::Grasshopper, Color::from((i % 2) as u8), i / 2 + 1),
+                true,
+            );
+        }
+        board.insert(
+            Position::new(-2, 0),
+            Piece::new_from(Bug::Ant, Color::Black, 1),
+            true,
+        );
+        board.remove(Position::new(1, 0));
+        assert_lazy_predicates_match_collected(&board);
+
+        let mut board = Board::new();
+        board.insert(
+            Position::new(0, 0),
+            Piece::new_from(Bug::Beetle, Color::White, 1),
+            true,
+        );
+        for (i, pos) in Position::new(0, 0).positions_around().enumerate() {
+            board.insert(
+                pos,
+                Piece::new_from(Bug::Grasshopper, Color::from((i % 2) as u8), i / 2 + 1),
+                true,
+            );
+        }
+        board.remove(Position::new(1, 0));
+        assert_lazy_predicates_match_collected(&board);
+
+        let mut board = Board::new();
+        board.insert(
+            Position::new(0, 0),
+            Piece::new_from(Bug::Mosquito, Color::White, 0),
+            true,
+        );
+        board.insert(
+            Position::new(1, 0),
+            Piece::new_from(Bug::Ant, Color::Black, 1),
+            true,
+        );
+        assert_lazy_predicates_match_collected(&board);
+    }
 
     #[test]
     fn tests_available_moves() {

--- a/engine/src/bug_stack.rs
+++ b/engine/src/bug_stack.rs
@@ -1,12 +1,14 @@
 use itertools::Itertools;
 
-use crate::{color::Color, piece::Piece};
+use crate::{color::Color, piece::Piece, position::Rotation};
 use std::fmt;
+
+const MISSING_INDEX: u16 = u16::MAX;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BugStack {
     pub pieces: [Piece; 7],
-    pub index: [Option<usize>; 2],
+    index: [u16; 2],
     pub size: u8,
 }
 
@@ -32,7 +34,7 @@ impl BugStack {
     pub fn new() -> Self {
         Self {
             pieces: [Piece::new().with_invalid(true); 7],
-            index: [None, None],
+            index: [MISSING_INDEX, MISSING_INDEX],
             size: 0,
         }
     }
@@ -81,6 +83,23 @@ impl BugStack {
 
     pub fn is_empty(&self) -> bool {
         self.size == 0
+    }
+
+    pub fn has_index(&self) -> bool {
+        self.index.iter().any(|index| *index != MISSING_INDEX)
+    }
+
+    pub fn index(&self, rotation: Rotation) -> Option<usize> {
+        let index = self.index[rotation as usize];
+        if index == MISSING_INDEX {
+            None
+        } else {
+            Some(index as usize)
+        }
+    }
+
+    pub fn set_index(&mut self, rotation: Rotation, index: usize) {
+        self.index[rotation as usize] = u16::try_from(index).expect("BugStack index fits in u16");
     }
 
     pub fn top_bug_color(&self) -> Option<Color> {

--- a/engine/src/game_control.rs
+++ b/engine/src/game_control.rs
@@ -107,7 +107,7 @@ mod tests {
         ]
         .iter()
         {
-            assert_eq!(Ok(gc), GameControl::from_str(&format!("{gc}")));
+            assert_eq!(Ok(gc), GameControl::from_str(&format!("{gc}")).as_ref());
         }
     }
 }

--- a/engine/src/game_type.rs
+++ b/engine/src/game_type.rs
@@ -53,6 +53,15 @@ impl FromStr for GameType {
 }
 
 impl GameType {
+    pub(crate) fn max_played(self) -> usize {
+        match self {
+            GameType::Base => 22,
+            GameType::M | GameType::L | GameType::P => 24,
+            GameType::ML | GameType::LP | GameType::MP => 26,
+            GameType::MLP => 28,
+        }
+    }
+
     pub(crate) fn add_m(self) -> Self {
         match self {
             GameType::Base => GameType::M,

--- a/engine/src/hasher.rs
+++ b/engine/src/hasher.rs
@@ -40,7 +40,7 @@ impl Hasher {
         }
         let index = if let Some(index) = index {
             index as u64
-        } else if let Some(index) = bug_stack.index[revolution as usize] {
+        } else if let Some(index) = bug_stack.index(revolution) {
             index as u64
         } else {
             panic!("We need an index");

--- a/engine/src/mid_move_board.rs
+++ b/engine/src/mid_move_board.rs
@@ -1,4 +1,4 @@
-use crate::{board::Board, bug_stack::BugStack, position::Position, torus_array::TorusArray};
+use crate::{board::Board, position::Position, torus_array::TorusArray};
 
 pub struct MidMoveBoard<'this> {
     pub board: &'this Board,
@@ -23,24 +23,30 @@ impl<'this> MidMoveBoard<'this> {
     }
 
     pub fn is_negative_space(&self, position: Position) -> bool {
-        *self.neighbor_count.get(position) > 0 && self.get(position).size == 0
+        *self.neighbor_count.get(position) > 0 && self.level(position) == 0
     }
 
     pub fn gated(&self, level: usize, from: Position, to: Position) -> bool {
         let (pos1, pos2) = from.common_adjacent_positions(to);
-        let p1 = self.get(pos1);
-        let p2 = self.get(pos2);
-        if p1.is_empty() || p2.is_empty() {
+        let level1 = self.level(pos1);
+        let level2 = self.level(pos2);
+        if level1 == 0 || level2 == 0 {
             return false;
         }
-        p1.len() >= level && p2.len() >= level
+        level1 >= level && level2 >= level
     }
 
-    pub fn get(&self, position: Position) -> BugStack {
-        let mut bug_stack = self.board.board.get(position).clone();
+    pub fn occupied(&self, position: Position) -> bool {
+        self.level(position) > 0
+    }
+
+    fn level(&self, position: Position) -> usize {
+        let mut level = self.board.level(position);
         if position == self.position_in_flight {
-            bug_stack.pop_piece();
+            level = level
+                .checked_sub(1)
+                .expect("Position in flight must contain a piece");
         }
-        bug_stack
+        level
     }
 }

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, fmt::Display, path::PathBuf, str::FromStr};
 
 use crate::{
     board::Board,
@@ -133,6 +133,22 @@ impl State {
         self.turn > 1 || !self.tournament
     }
 
+    fn invalid_move_error(
+        piece: Piece,
+        from: impl Display,
+        target_position: Position,
+        turn: usize,
+        reason: impl Into<String>,
+    ) -> GameError {
+        GameError::InvalidMove {
+            piece: piece.to_string(),
+            from: from.to_string(),
+            to: target_position.to_string(),
+            turn,
+            reason: reason.into(),
+        }
+    }
+
     // TODO: Think about renaming this to play_turn_from_str(ings)
     pub fn play_turn_from_history(&mut self, piece: &str, position: &str) -> Result<(), GameError> {
         match piece {
@@ -234,21 +250,23 @@ impl State {
     }
 
     fn turn_move(&mut self, piece: Piece, target_position: Position) -> Result<(), GameError> {
-        let mut err = GameError::InvalidMove {
-            piece: piece.to_string(),
-            from: "NA".to_string(),
-            to: target_position.to_string(),
-            turn: self.turn,
-            reason: "NA".to_string(),
-        };
-        let current_position = self.board.position_of_piece(piece).ok_or({
-            err.update_reason("This piece is not on the board.");
-            err.clone()
+        let current_position = self.board.position_of_piece(piece).ok_or_else(|| {
+            Self::invalid_move_error(
+                piece,
+                "NA",
+                target_position,
+                self.turn,
+                "This piece is not on the board.",
+            )
         })?;
-        err.update_from(current_position.to_string());
         if self.board.is_pinned(piece) {
-            err.update_reason("Piece is pinned.");
-            return Err(err);
+            return Err(Self::invalid_move_error(
+                piece,
+                current_position,
+                target_position,
+                self.turn,
+                "Piece is pinned.",
+            ));
         }
         // remove the piece from its current location
         if !self
@@ -256,8 +274,13 @@ impl State {
             .is_valid_move(self.turn_color, piece, current_position, target_position)
         {
             println!("Board state is: {}", self.board);
-            err.update_reason("This move isn't valid.");
-            return Err(err);
+            return Err(Self::invalid_move_error(
+                piece,
+                current_position,
+                target_position,
+                self.turn,
+                "This move isn't valid.",
+            ));
         }
         self.board
             .move_piece(piece, current_position, target_position, self.turn)?;
@@ -274,35 +297,49 @@ impl State {
     }
 
     pub fn turn_spawn(&mut self, piece: Piece, target_position: Position) -> Result<(), GameError> {
-        let mut err = GameError::InvalidMove {
-            piece: piece.to_string(),
-            from: "Reserve".to_string(),
-            to: target_position.to_string(),
-            turn: self.turn,
-            reason: "NA".to_string(),
-        };
         if !piece.is_color(self.turn_color) {
-            err.update_reason(format!(
+            let reason = format!(
                 "It is {}'s turn, but {} tried to spawn a piece.",
                 self.turn_color,
                 piece.color()
+            );
+            return Err(Self::invalid_move_error(
+                piece,
+                "Reserve",
+                target_position,
+                self.turn,
+                reason,
             ));
-            return Err(err);
         }
         if self.turn < 2 && piece.bug() == Bug::Queen && self.tournament {
-            err.update_reason("Can't spawn Queen. Game uses tournament rules");
-            return Err(err);
+            return Err(Self::invalid_move_error(
+                piece,
+                "Reserve",
+                target_position,
+                self.turn,
+                "Can't spawn Queen. Game uses tournament rules",
+            ));
         }
         if piece.bug() != Bug::Queen && self.board.queen_required(self.turn, piece.color()) {
-            err.update_reason("Can't spawn another piece. Queen is required.");
-            return Err(err);
+            return Err(Self::invalid_move_error(
+                piece,
+                "Reserve",
+                target_position,
+                self.turn,
+                "Can't spawn another piece. Queen is required.",
+            ));
         }
         if self.board.spawnable(piece.color(), target_position) {
             self.board.insert(target_position, piece, true);
             self.board.last_move = (None, Some(target_position));
         } else {
-            err.update_reason(format!("{} is not allowed to spawn here.", self.turn_color));
-            return Err(err);
+            return Err(Self::invalid_move_error(
+                piece,
+                "Reserve",
+                target_position,
+                self.turn,
+                format!("{} is not allowed to spawn here.", self.turn_color),
+            ));
         }
         Ok(())
     }


### PR DESCRIPTION
| Bench                                                                | Direction  | main          |HEAD          | HEAD vs main |
| Movegen 10k midpoint games, 10 passes | forward    | 8.535970s | 5.254180s | 1.625x              |
| Movegen 10k midpoint games, 10 passes | reverse     | 9.001965s | 5.196157s | 1.732x              |
|151K pgns                                                          | forward    | 7.484290s | 3.398908s | 2.202x faster  |
|151K pgns                                                          | reverse     | 7.629384s | 3.468688s | 2.200x faster  |