### PR TITLE
Add keyboard arrow-key history navigation to the game page

### DIFF
--- a/apis/src/components/atoms/history_button.rs
+++ b/apis/src/components/atoms/history_button.rs
@@ -1,8 +1,13 @@
 use crate::{
     components::organisms::side_board::move_query_signal,
-    providers::game_state::GameStateSignal,
+    providers::game_state::{GameStateSignal, View},
 };
-use leptos::{html, leptos_dom::helpers::debounce, prelude::*};
+use leptos::{
+    html,
+    leptos_dom::helpers::debounce,
+    prelude::*,
+    reactive::wrappers::write::SignalSetter,
+};
 use leptos_icons::*;
 
 #[derive(Clone)]
@@ -12,6 +17,20 @@ pub enum HistoryNavigation {
     Next,
     Previous,
     MobileLast,
+}
+
+pub fn sync_play_move_query(
+    game_state_signal: GameStateSignal,
+    set_move: &SignalSetter<Option<usize>>,
+) {
+    game_state_signal.signal.with_untracked(|gs| {
+        let move_param = match gs.view {
+            View::Game => None,
+            View::History => gs.history_turn.map(|turn| turn + 1),
+        };
+
+        set_move.set(move_param);
+    });
 }
 
 #[component]
@@ -45,12 +64,7 @@ pub fn HistoryButton(
         if let Some(post_action) = post_action {
             post_action.run(())
         }
-        let turn = game_state_signal.signal.with_untracked(|gs| match action {
-            HistoryNavigation::Last => Some(gs.state.turn),
-            HistoryNavigation::MobileLast => None,
-            _ => gs.history_turn.map(|v| v + 1),
-        });
-        set_move.set(turn);
+        sync_play_move_query(game_state_signal, &set_move);
     });
     let _definite_node_ref = node_ref.unwrap_or_default();
 

--- a/apis/src/components/molecules/history_controls.rs
+++ b/apis/src/components/molecules/history_controls.rs
@@ -6,8 +6,8 @@ use crate::{
     providers::game_state::GameStateSignal,
 };
 use hive_lib::Color;
-use leptos::{ev::keydown, html, prelude::*};
-use leptos_use::{use_event_listener, use_window};
+use leptos::{html, prelude::*};
+use leptos_use::use_window;
 
 #[component]
 pub fn HistoryControls(#[prop(optional)] parent: MaybeProp<NodeRef<html::Div>>) -> impl IntoView {
@@ -24,21 +24,6 @@ pub fn HistoryControls(#[prop(optional)] parent: MaybeProp<NodeRef<html::Div>>) 
     let focus = Callback::new(move |()| {
         if let Some(elem) = active.get_untracked() {
             elem.scroll_into_view_with_bool(false);
-        }
-    });
-    let prev_button = NodeRef::<html::Button>::new();
-    let next_button = NodeRef::<html::Button>::new();
-    _ = use_event_listener(document().body(), keydown, move |evt| {
-        if evt.key() == "ArrowLeft" {
-            evt.prevent_default();
-            if let Some(prev) = prev_button.get_untracked() {
-                prev.click()
-            };
-        } else if evt.key() == "ArrowRight" {
-            evt.prevent_default();
-            if let Some(next) = next_button.get_untracked() {
-                next.click()
-            };
         }
     });
 
@@ -58,16 +43,8 @@ pub fn HistoryControls(#[prop(optional)] parent: MaybeProp<NodeRef<html::Div>>) 
         <div>
             <div class="flex gap-1 min-h-0 [&>*]:grow">
                 <HistoryButton action=HistoryNavigation::First post_action=focus />
-                <HistoryButton
-                    node_ref=prev_button
-                    action=HistoryNavigation::Previous
-                    post_action=focus
-                />
-                <HistoryButton
-                    node_ref=next_button
-                    action=HistoryNavigation::Next
-                    post_action=if_last_go_to_end
-                />
+                <HistoryButton action=HistoryNavigation::Previous post_action=focus />
+                <HistoryButton action=HistoryNavigation::Next post_action=if_last_go_to_end />
                 <HistoryButton action=HistoryNavigation::Last post_action=scroll_to_end />
             </div>
             <div class="flex p-2">

--- a/apis/src/components/molecules/history_controls.rs
+++ b/apis/src/components/molecules/history_controls.rs
@@ -9,22 +9,22 @@ use hive_lib::Color;
 use leptos::{html, prelude::*};
 use leptos_use::use_window;
 
+pub fn scroll_active_history_move_into_view() {
+    let active = use_window()
+        .as_ref()
+        .and_then(|w| w.document())
+        .and_then(|d| d.query_selector(".bg-orange-twilight").ok())
+        .flatten();
+    if let Some(elem) = active {
+        elem.scroll_into_view_with_bool(false);
+    }
+}
+
 #[component]
 pub fn HistoryControls(#[prop(optional)] parent: MaybeProp<NodeRef<html::Div>>) -> impl IntoView {
     let game_state = expect_context::<GameStateSignal>();
-    let window = use_window();
-    let active = Signal::derive_local(move || {
-        window.as_ref().and_then(|w| {
-            w.document()
-                .expect("window to have a document")
-                .query_selector(".bg-orange-twilight")
-                .expect("to have an Element")
-        })
-    });
     let focus = Callback::new(move |()| {
-        if let Some(elem) = active.get_untracked() {
-            elem.scroll_into_view_with_bool(false);
-        }
+        scroll_active_history_move_into_view();
     });
 
     let scroll_to_end = Callback::new(move |()| {

--- a/apis/src/pages/play.rs
+++ b/apis/src/pages/play.rs
@@ -350,8 +350,9 @@ pub fn Play() -> impl IntoView {
             controls_signal.hidden.set(false);
         } else {
             // ArrowRight: navigate forward only when already browsing history.
-            let in_history =
-                game_state.signal.with_untracked(|gs| matches!(gs.view, View::History));
+            let in_history = game_state
+                .signal
+                .with_untracked(|gs| matches!(gs.view, View::History));
             if in_history {
                 game_state.next_history_turn();
             }

--- a/apis/src/pages/play.rs
+++ b/apis/src/pages/play.rs
@@ -1,19 +1,20 @@
 use crate::{
     common::{GameReaction, MoveConfirm, PieceType},
     components::{
-        atoms::history_button::{HistoryButton, HistoryNavigation},
+        atoms::history_button::{sync_play_move_query, HistoryButton, HistoryNavigation},
         layouts::base_layout::{ControlsSignal, OrientationSignal},
         molecules::{
             analysis_and_download::AnalysisAndDownload,
             control_buttons::ControlButtons,
             game_info::GameInfo,
+            history_controls::scroll_active_history_move_into_view,
             user_with_rating::UserWithRating,
         },
         organisms::{
             board::Board,
             display_timer::{DisplayTimer, Placement},
             reserve::{Alignment, Reserve},
-            side_board::{SideboardTabs, TabView},
+            side_board::{move_query_signal, SideboardTabs, TabView},
             unstarted::Unstarted,
         },
     },
@@ -59,6 +60,7 @@ pub fn Play() -> impl IntoView {
     let ws_ready = ws.ready_state;
     let params = use_params_map();
     let queries = use_query_map();
+    let (_move, set_move) = move_query_signal();
     let move_number = Signal::derive(move || {
         queries
             .get()
@@ -251,6 +253,7 @@ pub fn Play() -> impl IntoView {
                                         game_state.play_turn(piece, position);
                                         if was_at_live_edge {
                                             game_state.view_game();
+                                            sync_play_move_query(game_state, &set_move);
                                         }
                                         if let Some((piece, piece_type)) = active {
                                             match piece_type {
@@ -330,6 +333,9 @@ pub fn Play() -> impl IntoView {
         if key != "ArrowLeft" && key != "ArrowRight" {
             return;
         }
+        if evt.alt_key() || evt.ctrl_key() || evt.meta_key() || evt.shift_key() {
+            return;
+        }
         // Don't steal arrow keys from text inputs (chat, search fields, etc.).
         if let Some(target) = evt.target() {
             let tag = target
@@ -355,12 +361,22 @@ pub fn Play() -> impl IntoView {
                 .with_untracked(|gs| matches!(gs.view, View::Game));
             if entering {
                 game_state.signal.update(|gs| {
+                    gs.view_history();
                     gs.history_turn = gs.state.turn.checked_sub(1);
                 });
             }
-            game_state.previous_history_turn();
+            let can_step_back = game_state
+                .signal
+                .with_untracked(|gs| matches!(gs.history_turn, Some(turn) if turn > 0));
+            if can_step_back {
+                game_state.previous_history_turn();
+            } else if !entering {
+                return;
+            }
             tab.set(TabView::History);
             controls_signal.hidden.set(false);
+            sync_play_move_query(game_state, &set_move);
+            scroll_active_history_move_into_view();
         } else {
             // ArrowRight: navigate forward only when already browsing history.
             let in_history = game_state
@@ -368,6 +384,11 @@ pub fn Play() -> impl IntoView {
                 .with_untracked(|gs| matches!(gs.view, View::History));
             if in_history {
                 game_state.next_history_turn();
+                if game_state.signal.with_untracked(|gs| gs.is_last_turn()) {
+                    game_state.view_game();
+                }
+                sync_play_move_query(game_state, &set_move);
+                scroll_active_history_move_into_view();
             }
         }
     });

--- a/apis/src/pages/play.rs
+++ b/apis/src/pages/play.rs
@@ -37,6 +37,7 @@ use leptos_router::hooks::{use_params_map, use_query_map};
 use leptos_use::{use_event_listener, use_window};
 use shared_types::{GameId, GameStart};
 use uuid::Uuid;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 
 #[derive(Clone)]

--- a/apis/src/pages/play.rs
+++ b/apis/src/pages/play.rs
@@ -32,8 +32,9 @@ use crate::{
     websocket::client_handlers::game::{reset_game_state, reset_game_state_for_takeback},
 };
 use hive_lib::{Color, GameControl, GameResult, GameStatus, Turn};
-use leptos::prelude::*;
+use leptos::{ev::keydown, prelude::*};
 use leptos_router::hooks::{use_params_map, use_query_map};
+use leptos_use::{use_event_listener, use_window};
 use shared_types::{GameId, GameStart};
 use uuid::Uuid;
 use wasm_bindgen_futures::spawn_local;
@@ -233,19 +234,23 @@ pub fn Play() -> impl IntoView {
                             game_state.clear_gc();
                             game_state.set_game_response(gar.game.clone());
                             sounds.play_sound(SoundType::Turn);
-                            let (pos, reserve_pos, history_moves, active) =
+                            let (pos, reserve_pos, history_moves, active, was_at_live_edge) =
                                 game_state.signal.with_untracked(|gs| {
                                     (
                                         gs.move_info.current_position,
                                         gs.move_info.reserve_position,
                                         gs.state.history.moves.clone(),
                                         gs.move_info.active,
+                                        matches!(gs.view, View::History) && gs.is_last_turn(),
                                     )
                                 });
                             if history_moves != gar.game.history {
                                 match turn {
                                     Turn::Move(piece, position) => {
                                         game_state.play_turn(piece, position);
+                                        if was_at_live_edge {
+                                            game_state.view_game();
+                                        }
                                         if let Some((piece, piece_type)) = active {
                                             match piece_type {
                                                 PieceType::Board => {
@@ -314,6 +319,45 @@ pub fn Play() -> impl IntoView {
         },
         false,
     );
+
+    // Global keyboard handler: ArrowLeft enters history mode (from anywhere) and steps back;
+    // ArrowRight steps forward when already in history.
+    // use_window() returns None on SSR so use_event_listener becomes a no-op there.
+    let body = use_window().document().body();
+    _ = use_event_listener(body, keydown, move |evt| {
+        let key = evt.key();
+        if key != "ArrowLeft" && key != "ArrowRight" {
+            return;
+        }
+        evt.prevent_default();
+        if key == "ArrowLeft" {
+            let has_turns = game_state.signal.with_untracked(|gs| gs.state.turn > 0);
+            if !has_turns {
+                return;
+            }
+            // When entering from live game view, position to the last turn first so
+            // previous_history_turn() steps back one from the most-recent move.
+            let entering = game_state
+                .signal
+                .with_untracked(|gs| matches!(gs.view, View::Game) || gs.history_turn.is_none());
+            if entering {
+                game_state.signal.update(|gs| {
+                    gs.history_turn = gs.state.turn.checked_sub(1);
+                });
+            }
+            game_state.previous_history_turn();
+            tab.set(TabView::History);
+            controls_signal.hidden.set(false);
+        } else {
+            // ArrowRight: navigate forward only when already browsing history.
+            let in_history =
+                game_state.signal.with_untracked(|gs| matches!(gs.view, View::History));
+            if in_history {
+                game_state.next_history_turn();
+            }
+        }
+    });
+
     view! {
         <div class=move || {
             format!(

--- a/apis/src/pages/play.rs
+++ b/apis/src/pages/play.rs
@@ -329,6 +329,16 @@ pub fn Play() -> impl IntoView {
         if key != "ArrowLeft" && key != "ArrowRight" {
             return;
         }
+        // Don't steal arrow keys from text inputs (chat, search fields, etc.).
+        if let Some(target) = evt.target() {
+            let tag = target
+                .unchecked_ref::<web_sys::Element>()
+                .tag_name()
+                .to_uppercase();
+            if tag == "INPUT" || tag == "TEXTAREA" || tag == "SELECT" {
+                return;
+            }
+        }
         evt.prevent_default();
         if key == "ArrowLeft" {
             let has_turns = game_state.signal.with_untracked(|gs| gs.state.turn > 0);
@@ -337,9 +347,11 @@ pub fn Play() -> impl IntoView {
             }
             // When entering from live game view, position to the last turn first so
             // previous_history_turn() steps back one from the most-recent move.
+            // Don't re-trigger this if already in History view — that would teleport
+            // the user back to the end when they've navigated to the beginning.
             let entering = game_state
                 .signal
-                .with_untracked(|gs| matches!(gs.view, View::Game) || gs.history_turn.is_none());
+                .with_untracked(|gs| matches!(gs.view, View::Game));
             if entering {
                 game_state.signal.update(|gs| {
                     gs.history_turn = gs.state.turn.checked_sub(1);


### PR DESCRIPTION
- ArrowLeft from anywhere on the game page immediately enters history mode and steps back one move (lichess-style). Subsequent presses continue stepping back.
- ArrowRight steps forward when already browsing history.
- Removes the old per-component keyboard listener in history_controls, which only fired when the History tab was already open.
- Uses leptos_use SSR-safe wrappers (use_window/UseDocument) so the event listener is a no-op during server-side rendering.
- When the user is viewing the latest history move and an opponent move arrives, automatically snaps back to live view so they can respond without manually navigating forward.


https://github.com/user-attachments/assets/4e8c3e1c-49f1-4e35-b1e4-9719586bf692


https://github.com/user-attachments/assets/79b8bd10-0ebb-4b6b-b1fb-4d4263d41dce





