### PR TITLE
Adds hashes to games and creates game_hashes table

### DIFF
--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/lib.rs"
 name = "db_bin"
 path = "src/main.rs"
 
+[[bin]]
+name = "backfill_hashes"
+path = "src/backfill_hashes.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/db/migrations/2025-07-27-000000_create_game_hashes/down.sql
+++ b/db/migrations/2025-07-27-000000_create_game_hashes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE game_hashes;

--- a/db/migrations/2025-07-27-000000_create_game_hashes/up.sql
+++ b/db/migrations/2025-07-27-000000_create_game_hashes/up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE game_hashes (
+    hash BIGINT NOT NULL,
+    game_id UUID NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+    turn INT NOT NULL,
+    rating DOUBLE PRECISION,
+    result TEXT NOT NULL,
+    speed TEXT NOT NULL,
+    game_type TEXT NOT NULL,
+    rated BOOL NOT NULL,
+    played_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (game_id, turn)
+);
+
+CREATE INDEX game_hashes_hash_idx ON game_hashes (hash);

--- a/db/src/backfill_hashes.rs
+++ b/db/src/backfill_hashes.rs
@@ -1,0 +1,98 @@
+use db_lib::{
+    config::DbConfig,
+    get_conn, get_pool,
+    models::{Game, GameFinishContext, GameHash},
+};
+use hive_lib::State;
+use uuid::Uuid;
+
+const BATCH_SIZE: i64 = 200;
+
+#[tokio::main]
+async fn main() {
+    let config = DbConfig::from_env().expect("Failed to load config from env");
+    let pool = get_pool(&config.database_url)
+        .await
+        .expect("Failed to get pool");
+
+    let mut conn = get_conn(&pool).await.expect("Failed to get connection");
+    let remaining = Game::count_needing_hash_backfill(&mut conn)
+        .await
+        .expect("Failed to count games");
+    drop(conn);
+
+    if remaining == 0 {
+        println!("No games need backfilling.");
+        return;
+    }
+    println!("{remaining} games to backfill.");
+
+    let mut last_id: Option<Uuid> = None;
+    let mut total = 0_u64;
+
+    loop {
+        let mut conn = get_conn(&pool).await.expect("Failed to get connection");
+        let batch = Game::find_needing_hash_backfill(last_id, BATCH_SIZE, &mut conn)
+            .await
+            .expect("Failed to query games");
+
+        if batch.is_empty() {
+            break;
+        }
+
+        for game in &batch {
+            last_id = Some(game.id);
+
+            let state = match State::new_from_str(&game.history, &game.game_type) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!(
+                        "Skipping game {} (id {}): failed to replay history: {e}",
+                        game.nanoid, game.id
+                    );
+                    continue;
+                }
+            };
+
+            let new_hashes: Vec<Option<i64>> =
+                state.hashes.iter().map(|h| Some(*h as i64)).collect();
+
+            if let Err(e) = Game::set_hashes(game.id, new_hashes, &mut conn).await {
+                eprintln!(
+                    "Skipping game {} (id {}): failed to update hashes: {e}",
+                    game.nanoid, game.id
+                );
+                continue;
+            }
+
+            let ctx = GameFinishContext {
+                white_rating: game
+                    .white_rating
+                    .zip(game.white_rating_change)
+                    .map(|(r, c)| r + c),
+                black_rating: game
+                    .black_rating
+                    .zip(game.black_rating_change)
+                    .map(|(r, c)| r + c),
+                result: game.game_status.clone(),
+                speed: game.speed.clone(),
+                game_type: game.game_type.clone(),
+                rated: game.rated,
+                played_at: game.updated_at,
+            };
+            let hash_entries = GameHash::from_engine_hashes(game.id, &state.hashes, &ctx);
+            if let Err(e) = GameHash::insert_batch(&hash_entries, &mut conn).await {
+                eprintln!(
+                    "Warning: game {} (id {}): failed to insert game_hashes: {e}",
+                    game.nanoid, game.id
+                );
+            }
+
+            total += 1;
+        }
+
+        println!("Backfilled {total}/{remaining} games...");
+    }
+
+    println!("Done. Backfilled {total}/{remaining} games.");
+}

--- a/db/src/backfill_hashes.rs
+++ b/db/src/backfill_hashes.rs
@@ -3,6 +3,7 @@ use db_lib::{
     get_conn, get_pool,
     models::{Game, GameFinishContext, GameHash},
 };
+
 use hive_lib::State;
 use uuid::Uuid;
 
@@ -65,23 +66,8 @@ async fn main() {
                 continue;
             }
 
-            let ctx = GameFinishContext {
-                white_rating: game
-                    .white_rating
-                    .zip(game.white_rating_change)
-                    .map(|(r, c)| r + c),
-                black_rating: game
-                    .black_rating
-                    .zip(game.black_rating_change)
-                    .map(|(r, c)| r + c),
-                result: game.game_status.clone(),
-                speed: game.speed.clone(),
-                game_type: game.game_type.clone(),
-                rated: game.rated,
-                played_at: game.updated_at,
-            };
-            let hash_entries = GameHash::from_engine_hashes(game.id, &state.hashes, &ctx);
-            if let Err(e) = GameHash::insert_batch(&hash_entries, &mut conn).await {
+            let ctx = GameFinishContext::from_finished_game(game);
+            if let Err(e) = GameHash::insert_for_game(game.id, &state.hashes, &ctx, &mut conn).await {
                 eprintln!(
                     "Warning: game {} (id {}): failed to insert game_hashes: {e}",
                     game.nanoid, game.id

--- a/db/src/backfill_hashes.rs
+++ b/db/src/backfill_hashes.rs
@@ -1,6 +1,7 @@
 use db_lib::{
     config::DbConfig,
-    get_conn, get_pool,
+    get_conn,
+    get_pool,
     models::{Game, GameFinishContext, GameHash},
 };
 
@@ -67,7 +68,8 @@ async fn main() {
             }
 
             let ctx = GameFinishContext::from_finished_game(game);
-            if let Err(e) = GameHash::insert_for_game(game.id, &state.hashes, &ctx, &mut conn).await {
+            if let Err(e) = GameHash::insert_for_game(game.id, &state.hashes, &ctx, &mut conn).await
+            {
                 eprintln!(
                     "Warning: game {} (id {}): failed to insert game_hashes: {e}",
                     game.nanoid, game.id

--- a/db/src/models/game.rs
+++ b/db/src/models/game.rs
@@ -449,17 +449,8 @@ impl Game {
             ))
             .get_result(conn)
             .await?;
-        let ctx = GameFinishContext {
-            white_rating: new_white_rating_change.map(|c| white_rating_before + c),
-            black_rating: new_black_rating_change.map(|c| black_rating_before + c),
-            result: new_game_status.to_string(),
-            speed: self.speed.clone(),
-            game_type: self.game_type.clone(),
-            rated: self.rated,
-            played_at: Utc::now(),
-        };
-        let hash_entries = GameHash::from_engine_hashes(game.id, &self.hashes(), &ctx);
-        GameHash::insert_batch(&hash_entries, conn).await?;
+        let ctx = GameFinishContext::from_finished_game(&game);
+        GameHash::insert_for_game(game.id, &game.hashes(), &ctx, conn).await?;
         Ok(game)
     }
 
@@ -516,17 +507,8 @@ impl Game {
             ))
             .get_result(conn)
             .await?;
-        let ctx = GameFinishContext {
-            white_rating: new_white_rating_change.map(|c| white_rating_before + c),
-            black_rating: new_black_rating_change.map(|c| black_rating_before + c),
-            result: new_game_status.to_string(),
-            speed: self.speed.clone(),
-            game_type: self.game_type.clone(),
-            rated: self.rated,
-            played_at: Utc::now(),
-        };
-        let hash_entries = GameHash::from_engine_hashes(game.id, &self.hashes(), &ctx);
-        GameHash::insert_batch(&hash_entries, conn).await?;
+        let ctx = GameFinishContext::from_finished_game(&game);
+        GameHash::insert_for_game(game.id, &game.hashes(), &ctx, conn).await?;
         Ok(game)
     }
 
@@ -834,23 +816,14 @@ impl Game {
                             ))
                             .get_result(tc)
                             .await?;
-                        let ctx = GameFinishContext {
-                            white_rating: new_white_rating_change
-                                .map(|c| white_rating_before + c),
-                            black_rating: new_black_rating_change
-                                .map(|c| black_rating_before + c),
-                            result: new_game_status.to_string(),
-                            speed: game.speed.clone(),
-                            game_type: game.game_type.clone(),
-                            rated: game.rated,
-                            played_at: Utc::now(),
-                        };
-                        let hash_entries = GameHash::from_engine_hashes(
-                            game.id,
+                        let ctx = GameFinishContext::from_finished_game(&updated_game);
+                        GameHash::insert_for_game(
+                            updated_game.id,
                             &updated_game.hashes(),
                             &ctx,
-                        );
-                        GameHash::insert_batch(&hash_entries, tc).await?;
+                            tc,
+                        )
+                        .await?;
                         Ok(updated_game)
                     }
                     .scope_boxed()

--- a/db/src/models/game.rs
+++ b/db/src/models/game.rs
@@ -1,7 +1,7 @@
 use crate::{
     db_error::DbError,
     helpers::GameQueryBuilder,
-    models::{Challenge, GameUser, Rating, Tournament},
+    models::{Challenge, GameFinishContext, GameHash, GameUser, Rating, Tournament},
     schema::{
         challenges::{self, nanoid as nanoid_field},
         games::{self, dsl::*, tournament_game_result},
@@ -256,9 +256,10 @@ pub struct Game {
 
 impl Game {
     pub fn hashes(&self) -> Vec<u64> {
-        // WARN: @leex reimplement this
-        //self.hashes.iter().map(|i| *i as u64).collect::<Vec<u64>>()
-        vec![]
+        self.hashes
+            .iter()
+            .filter_map(|o| o.map(|i| i as u64))
+            .collect()
     }
 
     pub async fn create(new_game: NewGame, conn: &mut DbConn<'_>) -> Result<Game, DbError> {
@@ -432,7 +433,7 @@ impl Game {
             conn,
         )
         .await?;
-        Ok(diesel::update(games::table.find(self.id))
+        let game: Game = diesel::update(games::table.find(self.id))
             .set((
                 games::finished.eq(true),
                 games::tournament_game_result.eq(tgr.to_string()),
@@ -447,7 +448,19 @@ impl Game {
                 games::conclusion.eq(Conclusion::Timeout.to_string()),
             ))
             .get_result(conn)
-            .await?)
+            .await?;
+        let ctx = GameFinishContext {
+            white_rating: new_white_rating_change.map(|c| white_rating_before + c),
+            black_rating: new_black_rating_change.map(|c| black_rating_before + c),
+            result: new_game_status.to_string(),
+            speed: self.speed.clone(),
+            game_type: self.game_type.clone(),
+            rated: self.rated,
+            played_at: Utc::now(),
+        };
+        let hash_entries = GameHash::from_engine_hashes(game.id, &self.hashes(), &ctx);
+        GameHash::insert_batch(&hash_entries, conn).await?;
+        Ok(game)
     }
 
     async fn finish_game_control(
@@ -485,7 +498,7 @@ impl Game {
             conn,
         )
         .await?;
-        Ok(diesel::update(games::table.find(self.id))
+        let game: Game = diesel::update(games::table.find(self.id))
             .set((
                 games::finished.eq(true),
                 games::tournament_game_result.eq(tgr.to_string()),
@@ -502,7 +515,19 @@ impl Game {
                 games::conclusion.eq(final_conclusion.to_string()),
             ))
             .get_result(conn)
-            .await?)
+            .await?;
+        let ctx = GameFinishContext {
+            white_rating: new_white_rating_change.map(|c| white_rating_before + c),
+            black_rating: new_black_rating_change.map(|c| black_rating_before + c),
+            result: new_game_status.to_string(),
+            speed: self.speed.clone(),
+            game_type: self.game_type.clone(),
+            rated: self.rated,
+            played_at: Utc::now(),
+        };
+        let hash_entries = GameHash::from_engine_hashes(game.id, &self.hashes(), &ctx);
+        GameHash::insert_batch(&hash_entries, conn).await?;
+        Ok(game)
     }
 
     fn time_left_duration(&self, color: Color) -> Result<Duration, DbError> {
@@ -741,6 +766,8 @@ impl Game {
         };
 
         let new_move_times = self.get_move_times(&time_info, state);
+        let new_hashes: Vec<Option<i64>> =
+            state.hashes.iter().map(|h| Some(*h as i64)).collect();
 
         if time_info.timed_out {
             // Timeout supersedes the in-flight move and any implicit control rejection it carried.
@@ -783,7 +810,7 @@ impl Game {
                             tc,
                         )
                         .await?;
-                        Ok(diesel::update(games::table.find(game.id))
+                        let updated_game: Game = diesel::update(games::table.find(game.id))
                             .set((
                                 games::history.eq(new_history),
                                 games::current_player_id.eq(next_player),
@@ -802,10 +829,29 @@ impl Game {
                                 games::black_time_left.eq(new_black_time_left),
                                 games::last_interaction.eq(Some(Utc::now())),
                                 games::move_times.eq(new_move_times),
+                                games::hashes.eq(&new_hashes),
                                 games::conclusion.eq(new_conclusion.to_string()),
                             ))
                             .get_result(tc)
-                            .await?)
+                            .await?;
+                        let ctx = GameFinishContext {
+                            white_rating: new_white_rating_change
+                                .map(|c| white_rating_before + c),
+                            black_rating: new_black_rating_change
+                                .map(|c| black_rating_before + c),
+                            result: new_game_status.to_string(),
+                            speed: game.speed.clone(),
+                            game_type: game.game_type.clone(),
+                            rated: game.rated,
+                            played_at: Utc::now(),
+                        };
+                        let hash_entries = GameHash::from_engine_hashes(
+                            game.id,
+                            &updated_game.hashes(),
+                            &ctx,
+                        );
+                        GameHash::insert_batch(&hash_entries, tc).await?;
+                        Ok(updated_game)
                     }
                     .scope_boxed()
                 })
@@ -831,6 +877,7 @@ impl Game {
             white_time_left.eq(time_info.white_time_left),
             black_time_left.eq(time_info.black_time_left),
             move_times.eq(new_move_times),
+            hashes.eq(new_hashes),
             last_interaction.eq(Some(Utc::now())),
         ))
         .get_result(conn)
@@ -1054,6 +1101,7 @@ impl Game {
             updated_at.eq(Utc::now()),
             last_interaction.eq(Utc::now()),
             move_times.eq(new_move_times),
+            hashes.eq(state.hashes.iter().map(|h| Some(*h as i64)).collect::<Vec<Option<i64>>>()),
             white_time_left.eq(white_time),
             black_time_left.eq(black_time),
         ))
@@ -1428,5 +1476,45 @@ impl Game {
                 })
             })
             .collect())
+    }
+
+    pub async fn count_needing_hash_backfill(conn: &mut DbConn<'_>) -> Result<i64, DbError> {
+        Ok(games::table
+            .filter(games::history.ne(""))
+            .filter(games::finished.eq(true))
+            .filter(games::hashes.eq(Vec::<Option<i64>>::new()))
+            .count()
+            .get_result(conn)
+            .await?)
+    }
+
+    pub async fn find_needing_hash_backfill(
+        after_id: Option<Uuid>,
+        limit: i64,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Vec<Game>, DbError> {
+        let mut query = games::table
+            .filter(games::history.ne(""))
+            .filter(games::finished.eq(true))
+            .filter(games::hashes.eq(Vec::<Option<i64>>::new()))
+            .order(games::id.asc())
+            .limit(limit)
+            .into_boxed();
+        if let Some(after) = after_id {
+            query = query.filter(games::id.gt(after));
+        }
+        Ok(query.load(conn).await?)
+    }
+
+    pub async fn set_hashes(
+        game_id: Uuid,
+        new_hashes: Vec<Option<i64>>,
+        conn: &mut DbConn<'_>,
+    ) -> Result<(), DbError> {
+        diesel::update(games::table.find(game_id))
+            .set(games::hashes.eq(new_hashes))
+            .execute(conn)
+            .await?;
+        Ok(())
     }
 }

--- a/db/src/models/game.rs
+++ b/db/src/models/game.rs
@@ -748,8 +748,7 @@ impl Game {
         };
 
         let new_move_times = self.get_move_times(&time_info, state);
-        let new_hashes: Vec<Option<i64>> =
-            state.hashes.iter().map(|h| Some(*h as i64)).collect();
+        let new_hashes: Vec<Option<i64>> = state.hashes.iter().map(|h| Some(*h as i64)).collect();
 
         if time_info.timed_out {
             // Timeout supersedes the in-flight move and any implicit control rejection it carried.
@@ -1074,7 +1073,11 @@ impl Game {
             updated_at.eq(Utc::now()),
             last_interaction.eq(Utc::now()),
             move_times.eq(new_move_times),
-            hashes.eq(state.hashes.iter().map(|h| Some(*h as i64)).collect::<Vec<Option<i64>>>()),
+            hashes.eq(state
+                .hashes
+                .iter()
+                .map(|h| Some(*h as i64))
+                .collect::<Vec<Option<i64>>>()),
             white_time_left.eq(white_time),
             black_time_left.eq(black_time),
         ))

--- a/db/src/models/game_hash.rs
+++ b/db/src/models/game_hash.rs
@@ -1,0 +1,89 @@
+use crate::{db_error::DbError, schema::game_hashes, DbConn};
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+#[derive(Queryable, Insertable, Debug)]
+#[diesel(table_name = game_hashes)]
+pub struct GameHash {
+    pub hash: i64,
+    pub game_id: Uuid,
+    pub turn: i32,
+    pub rating: Option<f64>,
+    pub result: String,
+    pub speed: String,
+    pub game_type: String,
+    pub rated: bool,
+    pub played_at: DateTime<Utc>,
+}
+
+pub struct GameFinishContext {
+    pub white_rating: Option<f64>,
+    pub black_rating: Option<f64>,
+    pub result: String,
+    pub speed: String,
+    pub game_type: String,
+    pub rated: bool,
+    pub played_at: DateTime<Utc>,
+}
+
+impl GameHash {
+    pub fn from_engine_hashes(game_id: Uuid, hashes: &[u64], ctx: &GameFinishContext) -> Vec<Self> {
+        hashes
+            .iter()
+            .enumerate()
+            .map(|(turn, &h)| Self {
+                hash: h as i64,
+                game_id,
+                turn: turn as i32,
+                rating: if turn % 2 == 0 {
+                    ctx.white_rating
+                } else {
+                    ctx.black_rating
+                },
+                result: ctx.result.clone(),
+                speed: ctx.speed.clone(),
+                game_type: ctx.game_type.clone(),
+                rated: ctx.rated,
+                played_at: ctx.played_at,
+            })
+            .collect()
+    }
+
+    pub async fn insert_batch(entries: &[GameHash], conn: &mut DbConn<'_>) -> Result<(), DbError> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        diesel::insert_into(game_hashes::table)
+            .values(entries)
+            .on_conflict_do_nothing()
+            .execute(conn)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn find_by_hash(
+        hash: u64,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Vec<GameHash>, DbError> {
+        Ok(game_hashes::table
+            .filter(game_hashes::hash.eq(hash as i64))
+            .load(conn)
+            .await?)
+    }
+
+    pub async fn best(
+        hash: u64,
+        limit: Option<i64>,
+        conn: &mut DbConn<'_>,
+    ) -> Result<Vec<GameHash>, DbError> {
+        Ok(game_hashes::table
+            .filter(game_hashes::hash.eq(hash as i64))
+            .filter(game_hashes::rating.is_not_null())
+            .order(game_hashes::rating.desc())
+            .limit(limit.unwrap_or(10))
+            .load(conn)
+            .await?)
+    }
+}

--- a/db/src/models/game_hash.rs
+++ b/db/src/models/game_hash.rs
@@ -32,8 +32,14 @@ pub struct GameFinishContext {
 impl GameFinishContext {
     pub fn from_finished_game(game: &Game) -> Self {
         Self {
-            white_rating: game.white_rating.zip(game.white_rating_change).map(|(r, c)| r + c),
-            black_rating: game.black_rating.zip(game.black_rating_change).map(|(r, c)| r + c),
+            white_rating: game
+                .white_rating
+                .zip(game.white_rating_change)
+                .map(|(r, c)| r + c),
+            black_rating: game
+                .black_rating
+                .zip(game.black_rating_change)
+                .map(|(r, c)| r + c),
             result: game.game_status.clone(),
             speed: game.speed.clone(),
             game_type: game.game_type.clone(),
@@ -88,10 +94,7 @@ impl GameHash {
         Self::insert_batch(&entries, conn).await
     }
 
-    pub async fn find_by_hash(
-        hash: u64,
-        conn: &mut DbConn<'_>,
-    ) -> Result<Vec<GameHash>, DbError> {
+    pub async fn find_by_hash(hash: u64, conn: &mut DbConn<'_>) -> Result<Vec<GameHash>, DbError> {
         Ok(game_hashes::table
             .filter(game_hashes::hash.eq(hash as i64))
             .load(conn)

--- a/db/src/models/game_hash.rs
+++ b/db/src/models/game_hash.rs
@@ -1,3 +1,4 @@
+use super::game::Game;
 use crate::{db_error::DbError, schema::game_hashes, DbConn};
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
@@ -26,6 +27,20 @@ pub struct GameFinishContext {
     pub game_type: String,
     pub rated: bool,
     pub played_at: DateTime<Utc>,
+}
+
+impl GameFinishContext {
+    pub fn from_finished_game(game: &Game) -> Self {
+        Self {
+            white_rating: game.white_rating.zip(game.white_rating_change).map(|(r, c)| r + c),
+            black_rating: game.black_rating.zip(game.black_rating_change).map(|(r, c)| r + c),
+            result: game.game_status.clone(),
+            speed: game.speed.clone(),
+            game_type: game.game_type.clone(),
+            rated: game.rated,
+            played_at: game.updated_at,
+        }
+    }
 }
 
 impl GameHash {
@@ -61,6 +76,16 @@ impl GameHash {
             .execute(conn)
             .await?;
         Ok(())
+    }
+
+    pub async fn insert_for_game(
+        game_id: Uuid,
+        hashes: &[u64],
+        ctx: &GameFinishContext,
+        conn: &mut DbConn<'_>,
+    ) -> Result<(), DbError> {
+        let entries = Self::from_engine_hashes(game_id, hashes, ctx);
+        Self::insert_batch(&entries, conn).await
     }
 
     pub async fn find_by_hash(

--- a/db/src/models/mod.rs
+++ b/db/src/models/mod.rs
@@ -1,5 +1,6 @@
 mod challenge;
 mod game;
+mod game_hash;
 mod game_user;
 mod home_banner;
 mod rating;
@@ -13,6 +14,7 @@ mod tournament_user;
 mod user;
 pub use challenge::{Challenge, NewChallenge};
 pub use game::{Game, NewGame};
+pub use game_hash::{GameFinishContext, GameHash};
 pub use game_user::GameUser;
 pub use home_banner::HomeBanner;
 pub use rating::{NewRating, Rating};

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -21,6 +21,20 @@ diesel::table! {
 }
 
 diesel::table! {
+    game_hashes (game_id, turn) {
+        hash -> Int8,
+        game_id -> Uuid,
+        turn -> Int4,
+        rating -> Nullable<Float8>,
+        result -> Text,
+        speed -> Text,
+        game_type -> Text,
+        rated -> Bool,
+        played_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     games (id) {
         id -> Uuid,
         nanoid -> Text,
@@ -70,6 +84,34 @@ diesel::table! {
         title -> Text,
         content -> Text,
         display -> Bool,
+    }
+}
+
+diesel::table! {
+    notification_preferences (user_id) {
+        user_id -> Uuid,
+        your_turn -> Array<Nullable<Text>>,
+        challenges -> Array<Nullable<Text>>,
+        game_ended -> Array<Nullable<Text>>,
+        tournament -> Array<Nullable<Text>>,
+        general_chat -> Array<Nullable<Text>>,
+        dms -> Array<Nullable<Text>>,
+        quiet_start -> Nullable<Int2>,
+        quiet_end -> Nullable<Int2>,
+        timezone -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    push_devices (id) {
+        id -> Uuid,
+        user_id -> Uuid,
+        platform -> Text,
+        device_token -> Text,
+        app_version -> Text,
+        locale -> Text,
+        created_at -> Timestamptz,
+        last_seen_at -> Timestamptz,
     }
 }
 
@@ -189,8 +231,11 @@ diesel::table! {
     }
 }
 
+diesel::joinable!(game_hashes -> games (game_id));
 diesel::joinable!(games_users -> games (game_id));
 diesel::joinable!(games_users -> users (user_id));
+diesel::joinable!(notification_preferences -> users (user_id));
+diesel::joinable!(push_devices -> users (user_id));
 diesel::joinable!(ratings -> users (user_uid));
 diesel::joinable!(schedules -> games (game_id));
 diesel::joinable!(schedules -> tournaments (tournament_id));
@@ -206,9 +251,12 @@ diesel::joinable!(tournaments_users -> users (user_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     challenges,
+    game_hashes,
     games,
     games_users,
     home_banner,
+    notification_preferences,
+    push_devices,
     ratings,
     schedules,
     tournament_series,

--- a/db/tests/game_hashes.rs
+++ b/db/tests/game_hashes.rs
@@ -124,7 +124,9 @@ async fn same_hash_across_multiple_games() {
     GameHash::insert_batch(&entries_a, &mut conn).await.unwrap();
     GameHash::insert_batch(&entries_b, &mut conn).await.unwrap();
 
-    let found = GameHash::find_by_hash(shared_hash, &mut conn).await.unwrap();
+    let found = GameHash::find_by_hash(shared_hash, &mut conn)
+        .await
+        .unwrap();
     assert_eq!(found.len(), 2);
 
     let game_ids: Vec<uuid::Uuid> = found.iter().map(|e| e.game_id).collect();
@@ -171,8 +173,14 @@ async fn cascade_delete_removes_hash_entries_when_game_deleted() {
 
     game.delete(&mut conn).await.unwrap();
 
-    assert!(GameHash::find_by_hash(777, &mut conn).await.unwrap().is_empty());
-    assert!(GameHash::find_by_hash(888, &mut conn).await.unwrap().is_empty());
+    assert!(GameHash::find_by_hash(777, &mut conn)
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(GameHash::find_by_hash(888, &mut conn)
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -180,7 +188,9 @@ async fn find_nonexistent_hash_returns_empty() {
     let db = common::db::test_db().await;
     let mut conn = get_conn(&db.pool).await.unwrap();
 
-    let found = GameHash::find_by_hash(0xDEAD_BEEF, &mut conn).await.unwrap();
+    let found = GameHash::find_by_hash(0xDEAD_BEEF, &mut conn)
+        .await
+        .unwrap();
     assert!(found.is_empty());
 }
 
@@ -262,8 +272,12 @@ async fn best_defaults_to_10() {
 
     let hash = 0xDEF_u64;
     for i in 0..15 {
-        let (g, _, _) =
-            setup_game_named(&format!("d{}", i * 2), &format!("d{}", i * 2 + 1), &mut conn).await;
+        let (g, _, _) = setup_game_named(
+            &format!("d{}", i * 2),
+            &format!("d{}", i * 2 + 1),
+            &mut conn,
+        )
+        .await;
         let ctx = test_ctx(Some(1000.0 + i as f64), None);
         let entries = GameHash::from_engine_hashes(g.id, &[hash], &ctx);
         GameHash::insert_batch(&entries, &mut conn).await.unwrap();
@@ -335,7 +349,9 @@ async fn game_hashes_accessor_roundtrips_through_set_hashes() {
 
     let original: Vec<u64> = vec![0, 1, u64::MAX, 0xDEAD_BEEF_CAFE_BABE];
     let db_hashes: Vec<Option<i64>> = original.iter().map(|h| Some(*h as i64)).collect();
-    Game::set_hashes(game.id, db_hashes, &mut conn).await.unwrap();
+    Game::set_hashes(game.id, db_hashes, &mut conn)
+        .await
+        .unwrap();
 
     let reloaded: Game = games::table.find(game.id).first(&mut conn).await.unwrap();
     assert_eq!(reloaded.hashes(), original);
@@ -430,17 +446,15 @@ async fn backfill_cursor_pagination_works() {
         .unwrap();
     assert_eq!(first_batch.len(), 1);
 
-    let second_batch =
-        Game::find_needing_hash_backfill(Some(first_batch[0].id), 1, &mut conn)
-            .await
-            .unwrap();
+    let second_batch = Game::find_needing_hash_backfill(Some(first_batch[0].id), 1, &mut conn)
+        .await
+        .unwrap();
     assert_eq!(second_batch.len(), 1);
     assert_ne!(first_batch[0].id, second_batch[0].id);
 
-    let third_batch =
-        Game::find_needing_hash_backfill(Some(second_batch[0].id), 1, &mut conn)
-            .await
-            .unwrap();
+    let third_batch = Game::find_needing_hash_backfill(Some(second_batch[0].id), 1, &mut conn)
+        .await
+        .unwrap();
     assert!(third_batch.is_empty());
 }
 
@@ -465,11 +479,15 @@ async fn backfill_replays_history_and_populates_both_tables() {
     assert!(!state.hashes.is_empty());
 
     let db_hashes: Vec<Option<i64>> = state.hashes.iter().map(|h| Some(*h as i64)).collect();
-    Game::set_hashes(game.id, db_hashes, &mut conn).await.unwrap();
+    Game::set_hashes(game.id, db_hashes, &mut conn)
+        .await
+        .unwrap();
 
     let ctx = test_ctx(None, None);
     let hash_entries = GameHash::from_engine_hashes(game.id, &state.hashes, &ctx);
-    GameHash::insert_batch(&hash_entries, &mut conn).await.unwrap();
+    GameHash::insert_batch(&hash_entries, &mut conn)
+        .await
+        .unwrap();
 
     let reloaded: Game = games::table.find(game.id).first(&mut conn).await.unwrap();
     assert_eq!(reloaded.hashes(), state.hashes);
@@ -491,11 +509,7 @@ async fn setup_game(conn: &mut db_lib::DbConn<'_>) -> (Game, User, User) {
     setup_game_with_history("alice", "bob", "", conn).await
 }
 
-async fn setup_game_named(
-    w: &str,
-    b: &str,
-    conn: &mut db_lib::DbConn<'_>,
-) -> (Game, User, User) {
+async fn setup_game_named(w: &str, b: &str, conn: &mut db_lib::DbConn<'_>) -> (Game, User, User) {
     setup_game_with_history(w, b, "", conn).await
 }
 

--- a/db/tests/game_hashes.rs
+++ b/db/tests/game_hashes.rs
@@ -1,0 +1,569 @@
+mod common;
+
+use chrono::Utc;
+use db_lib::{
+    get_conn,
+    models::{Game, GameFinishContext, GameHash, NewGame, NewUser, User},
+    schema::{game_hashes as gh_schema, games},
+};
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use hive_lib::{GameStatus, GameType, State};
+use shared_types::{Conclusion, GameSpeed, GameStart, TimeMode, TournamentGameResult};
+
+fn test_ctx(white_rating: Option<f64>, black_rating: Option<f64>) -> GameFinishContext {
+    GameFinishContext {
+        white_rating,
+        black_rating,
+        result: "Finished(Winner(White))".to_string(),
+        speed: GameSpeed::Bullet.to_string(),
+        game_type: GameType::MLP.to_string(),
+        rated: true,
+        played_at: Utc::now(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — GameHash::from_engine_hashes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn alternates_white_and_black_ratings_by_turn() {
+    let id = uuid::Uuid::new_v4();
+    let ctx = test_ctx(Some(1500.0), Some(1700.0));
+    let entries = GameHash::from_engine_hashes(id, &[10, 20, 30, 40], &ctx);
+
+    assert_eq!(entries.len(), 4);
+    for (i, e) in entries.iter().enumerate() {
+        assert_eq!(e.game_id, id);
+        assert_eq!(e.turn, i as i32);
+        assert_eq!(e.result, ctx.result);
+        assert_eq!(e.speed, ctx.speed);
+        assert_eq!(e.game_type, ctx.game_type);
+        assert!(e.rated);
+    }
+    // Even turns → white, odd → black
+    assert_eq!(entries[0].rating, Some(1500.0));
+    assert_eq!(entries[1].rating, Some(1700.0));
+    assert_eq!(entries[2].rating, Some(1500.0));
+    assert_eq!(entries[3].rating, Some(1700.0));
+}
+
+#[test]
+fn none_rating_propagates_to_matching_turns() {
+    let id = uuid::Uuid::new_v4();
+    let ctx = test_ctx(None, Some(1600.0));
+    let entries = GameHash::from_engine_hashes(id, &[1, 2], &ctx);
+
+    assert_eq!(entries[0].rating, None); // white is None
+    assert_eq!(entries[1].rating, Some(1600.0));
+}
+
+#[test]
+fn empty_hashes_produce_no_entries() {
+    let ctx = test_ctx(Some(1.0), Some(2.0));
+    let entries = GameHash::from_engine_hashes(uuid::Uuid::new_v4(), &[], &ctx);
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn u64_i64_roundtrip_preserves_high_bit_values() {
+    let big: u64 = 0xFFFF_FFFF_FFFF_FFFF;
+    let ctx = test_ctx(None, None);
+    let entries = GameHash::from_engine_hashes(uuid::Uuid::new_v4(), &[big], &ctx);
+    // The stored i64 is the bitwise reinterpretation: -1
+    assert_eq!(entries[0].hash, -1_i64);
+    // Converting back gives the original u64
+    assert_eq!(entries[0].hash as u64, big);
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests — DB round-trips
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_and_find_returns_correct_entries() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+    let (game, _, _) = setup_game(&mut conn).await;
+
+    let ctx = test_ctx(Some(1500.0), Some(1600.0));
+    let entries = GameHash::from_engine_hashes(game.id, &[100, 200], &ctx);
+    GameHash::insert_batch(&entries, &mut conn).await.unwrap();
+
+    let found = GameHash::find_by_hash(100, &mut conn).await.unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].game_id, game.id);
+    assert_eq!(found[0].turn, 0);
+    assert_eq!(found[0].rating, Some(1500.0));
+    assert_eq!(found[0].speed, GameSpeed::Bullet.to_string());
+    assert!(found[0].rated);
+
+    let found2 = GameHash::find_by_hash(200, &mut conn).await.unwrap();
+    assert_eq!(found2.len(), 1);
+    assert_eq!(found2[0].turn, 1);
+    assert_eq!(found2[0].rating, Some(1600.0));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn same_hash_across_multiple_games() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let shared_hash = 0xCAFE_u64;
+
+    let (game_a, _, _) = setup_game_named("a1", "a2", &mut conn).await;
+    let (game_b, _, _) = setup_game_named("b1", "b2", &mut conn).await;
+
+    let ctx_a = test_ctx(Some(1500.0), None);
+    let ctx_b = test_ctx(None, Some(1800.0));
+
+    let entries_a = GameHash::from_engine_hashes(game_a.id, &[shared_hash], &ctx_a);
+    let entries_b = GameHash::from_engine_hashes(game_b.id, &[shared_hash, 999], &ctx_b);
+
+    GameHash::insert_batch(&entries_a, &mut conn).await.unwrap();
+    GameHash::insert_batch(&entries_b, &mut conn).await.unwrap();
+
+    let found = GameHash::find_by_hash(shared_hash, &mut conn).await.unwrap();
+    assert_eq!(found.len(), 2);
+
+    let game_ids: Vec<uuid::Uuid> = found.iter().map(|e| e.game_id).collect();
+    assert!(game_ids.contains(&game_a.id));
+    assert!(game_ids.contains(&game_b.id));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn duplicate_insert_is_idempotent() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+    let (game, _, _) = setup_game(&mut conn).await;
+
+    let ctx = test_ctx(None, None);
+    let entries = GameHash::from_engine_hashes(game.id, &[42], &ctx);
+    GameHash::insert_batch(&entries, &mut conn).await.unwrap();
+    GameHash::insert_batch(&entries, &mut conn).await.unwrap();
+
+    let found = GameHash::find_by_hash(42, &mut conn).await.unwrap();
+    assert_eq!(found.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_batch_insert_is_noop() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+    GameHash::insert_batch(&[], &mut conn).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cascade_delete_removes_hash_entries_when_game_deleted() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+    let (game, _, _) = setup_game(&mut conn).await;
+
+    let ctx = test_ctx(Some(1500.0), Some(1600.0));
+    let entries = GameHash::from_engine_hashes(game.id, &[777, 888], &ctx);
+    GameHash::insert_batch(&entries, &mut conn).await.unwrap();
+
+    assert_eq!(
+        GameHash::find_by_hash(777, &mut conn).await.unwrap().len(),
+        1
+    );
+
+    game.delete(&mut conn).await.unwrap();
+
+    assert!(GameHash::find_by_hash(777, &mut conn).await.unwrap().is_empty());
+    assert!(GameHash::find_by_hash(888, &mut conn).await.unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn find_nonexistent_hash_returns_empty() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let found = GameHash::find_by_hash(0xDEAD_BEEF, &mut conn).await.unwrap();
+    assert!(found.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests — GameHash::best
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn best_returns_highest_rated_games_first() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let hash = 0xBE57_u64;
+    let (g1, _, _) = setup_game_named("lo1", "lo2", &mut conn).await;
+    let (g2, _, _) = setup_game_named("mid1", "mid2", &mut conn).await;
+    let (g3, _, _) = setup_game_named("hi1", "hi2", &mut conn).await;
+
+    for (gid, rating) in [(g1.id, 1200.0), (g2.id, 1800.0), (g3.id, 2400.0)] {
+        let ctx = test_ctx(Some(rating), None);
+        let entries = GameHash::from_engine_hashes(gid, &[hash], &ctx);
+        GameHash::insert_batch(&entries, &mut conn).await.unwrap();
+    }
+
+    let best = GameHash::best(hash, None, &mut conn).await.unwrap();
+    assert_eq!(best.len(), 3);
+    assert_eq!(best[0].game_id, g3.id); // 2400
+    assert_eq!(best[1].game_id, g2.id); // 1800
+    assert_eq!(best[2].game_id, g1.id); // 1200
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn best_respects_limit() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let hash = 0x1111_u64;
+    let (g1, _, _) = setup_game_named("l1", "l2", &mut conn).await;
+    let (g2, _, _) = setup_game_named("l3", "l4", &mut conn).await;
+    let (g3, _, _) = setup_game_named("l5", "l6", &mut conn).await;
+
+    for (gid, rating) in [(g1.id, 1000.0), (g2.id, 2000.0), (g3.id, 3000.0)] {
+        let ctx = test_ctx(Some(rating), None);
+        let entries = GameHash::from_engine_hashes(gid, &[hash], &ctx);
+        GameHash::insert_batch(&entries, &mut conn).await.unwrap();
+    }
+
+    let best = GameHash::best(hash, Some(2), &mut conn).await.unwrap();
+    assert_eq!(best.len(), 2);
+    assert_eq!(best[0].rating, Some(3000.0));
+    assert_eq!(best[1].rating, Some(2000.0));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn best_excludes_null_ratings() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let hash = 0x2222_u64;
+    let (g1, _, _) = setup_game_named("n1", "n2", &mut conn).await;
+    let (g2, _, _) = setup_game_named("n3", "n4", &mut conn).await;
+
+    let ctx_unrated = test_ctx(None, None);
+    let ctx_rated = test_ctx(Some(1500.0), None);
+
+    let entries1 = GameHash::from_engine_hashes(g1.id, &[hash], &ctx_unrated);
+    let entries2 = GameHash::from_engine_hashes(g2.id, &[hash], &ctx_rated);
+    GameHash::insert_batch(&entries1, &mut conn).await.unwrap();
+    GameHash::insert_batch(&entries2, &mut conn).await.unwrap();
+
+    let best = GameHash::best(hash, None, &mut conn).await.unwrap();
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].game_id, g2.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn best_defaults_to_10() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let hash = 0xDEF_u64;
+    for i in 0..15 {
+        let (g, _, _) =
+            setup_game_named(&format!("d{}", i * 2), &format!("d{}", i * 2 + 1), &mut conn).await;
+        let ctx = test_ctx(Some(1000.0 + i as f64), None);
+        let entries = GameHash::from_engine_hashes(g.id, &[hash], &ctx);
+        GameHash::insert_batch(&entries, &mut conn).await.unwrap();
+    }
+
+    let best = GameHash::best(hash, None, &mut conn).await.unwrap();
+    assert_eq!(best.len(), 10);
+    assert_eq!(best[0].rating, Some(1014.0));
+    assert_eq!(best[9].rating, Some(1005.0));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn best_returns_empty_for_unknown_hash() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let best = GameHash::best(0x3333, None, &mut conn).await.unwrap();
+    assert!(best.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests — denormalized fields round-trip
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn denormalized_fields_are_stored_and_retrieved() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+    let (game, _, _) = setup_game(&mut conn).await;
+
+    let ctx = GameFinishContext {
+        white_rating: Some(2000.0),
+        black_rating: Some(1800.0),
+        result: "Finished(Draw)".to_string(),
+        speed: GameSpeed::Correspondence.to_string(),
+        game_type: "Base".to_string(),
+        rated: false,
+        played_at: Utc::now(),
+    };
+    let entries = GameHash::from_engine_hashes(game.id, &[555], &ctx);
+    GameHash::insert_batch(&entries, &mut conn).await.unwrap();
+
+    let found = GameHash::find_by_hash(555, &mut conn).await.unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].result, "Finished(Draw)");
+    assert_eq!(found[0].speed, GameSpeed::Correspondence.to_string());
+    assert_eq!(found[0].game_type, "Base");
+    assert!(!found[0].rated);
+    assert_eq!(found[0].rating, Some(2000.0));
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests — Game.hashes() accessor
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn game_hashes_accessor_returns_empty_for_new_game() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+    let (game, _, _) = setup_game(&mut conn).await;
+    assert!(game.hashes().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn game_hashes_accessor_roundtrips_through_set_hashes() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+    let (game, _, _) = setup_game(&mut conn).await;
+
+    let original: Vec<u64> = vec![0, 1, u64::MAX, 0xDEAD_BEEF_CAFE_BABE];
+    let db_hashes: Vec<Option<i64>> = original.iter().map(|h| Some(*h as i64)).collect();
+    Game::set_hashes(game.id, db_hashes, &mut conn).await.unwrap();
+
+    let reloaded: Game = games::table.find(game.id).first(&mut conn).await.unwrap();
+    assert_eq!(reloaded.hashes(), original);
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests — backfill query methods
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backfill_query_finds_finished_games_with_empty_hashes() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let (game, _, _) = setup_game_with_history("f1", "f2", "wQ;bQ /wQ;", &mut conn).await;
+
+    let empty = Game::find_needing_hash_backfill(None, 100, &mut conn)
+        .await
+        .unwrap();
+    assert!(empty.is_empty());
+
+    diesel::update(games::table.find(game.id))
+        .set(games::finished.eq(true))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let needing = Game::find_needing_hash_backfill(None, 100, &mut conn)
+        .await
+        .unwrap();
+    assert_eq!(needing.len(), 1);
+    assert_eq!(needing[0].id, game.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backfill_query_skips_games_with_populated_hashes() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let (game, _, _) = setup_game_with_history("g1", "g2", "wQ;bQ /wQ;", &mut conn).await;
+    diesel::update(games::table.find(game.id))
+        .set(games::finished.eq(true))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    Game::set_hashes(game.id, vec![Some(1)], &mut conn)
+        .await
+        .unwrap();
+
+    let needing = Game::find_needing_hash_backfill(None, 100, &mut conn)
+        .await
+        .unwrap();
+    assert!(needing.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backfill_query_skips_games_with_empty_history() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let (game, _, _) = setup_game_with_history("h1", "h2", "", &mut conn).await;
+    diesel::update(games::table.find(game.id))
+        .set(games::finished.eq(true))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let needing = Game::find_needing_hash_backfill(None, 100, &mut conn)
+        .await
+        .unwrap();
+    assert!(needing.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backfill_cursor_pagination_works() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let (g1, _, _) = setup_game_with_history("p1", "p2", "wQ;", &mut conn).await;
+    let (g2, _, _) = setup_game_with_history("p3", "p4", "wQ;", &mut conn).await;
+    for gid in [g1.id, g2.id] {
+        diesel::update(games::table.find(gid))
+            .set(games::finished.eq(true))
+            .execute(&mut conn)
+            .await
+            .unwrap();
+    }
+
+    let first_batch = Game::find_needing_hash_backfill(None, 1, &mut conn)
+        .await
+        .unwrap();
+    assert_eq!(first_batch.len(), 1);
+
+    let second_batch =
+        Game::find_needing_hash_backfill(Some(first_batch[0].id), 1, &mut conn)
+            .await
+            .unwrap();
+    assert_eq!(second_batch.len(), 1);
+    assert_ne!(first_batch[0].id, second_batch[0].id);
+
+    let third_batch =
+        Game::find_needing_hash_backfill(Some(second_batch[0].id), 1, &mut conn)
+            .await
+            .unwrap();
+    assert!(third_batch.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Integration test — full backfill flow (replay + set_hashes + game_hashes)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backfill_replays_history_and_populates_both_tables() {
+    let db = common::db::test_db().await;
+    let mut conn = get_conn(&db.pool).await.unwrap();
+
+    let history = "wQ;bQ /wQ;";
+    let (game, _, _) = setup_game_with_history("r1", "r2", history, &mut conn).await;
+    diesel::update(games::table.find(game.id))
+        .set(games::finished.eq(true))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let state = State::new_from_str(history, &GameType::MLP.to_string()).unwrap();
+    assert!(!state.hashes.is_empty());
+
+    let db_hashes: Vec<Option<i64>> = state.hashes.iter().map(|h| Some(*h as i64)).collect();
+    Game::set_hashes(game.id, db_hashes, &mut conn).await.unwrap();
+
+    let ctx = test_ctx(None, None);
+    let hash_entries = GameHash::from_engine_hashes(game.id, &state.hashes, &ctx);
+    GameHash::insert_batch(&hash_entries, &mut conn).await.unwrap();
+
+    let reloaded: Game = games::table.find(game.id).first(&mut conn).await.unwrap();
+    assert_eq!(reloaded.hashes(), state.hashes);
+
+    let count: i64 = gh_schema::table
+        .filter(gh_schema::game_id.eq(game.id))
+        .count()
+        .get_result(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(count, state.hashes.len() as i64);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn setup_game(conn: &mut db_lib::DbConn<'_>) -> (Game, User, User) {
+    setup_game_with_history("alice", "bob", "", conn).await
+}
+
+async fn setup_game_named(
+    w: &str,
+    b: &str,
+    conn: &mut db_lib::DbConn<'_>,
+) -> (Game, User, User) {
+    setup_game_with_history(w, b, "", conn).await
+}
+
+async fn setup_game_with_history(
+    white_name: &str,
+    black_name: &str,
+    history: &str,
+    conn: &mut db_lib::DbConn<'_>,
+) -> (Game, User, User) {
+    let white = User::create(
+        NewUser::new(white_name, "password", &format!("{white_name}@test.com")).unwrap(),
+        conn,
+    )
+    .await
+    .unwrap();
+    let black = User::create(
+        NewUser::new(black_name, "password", &format!("{black_name}@test.com")).unwrap(),
+        conn,
+    )
+    .await
+    .unwrap();
+
+    let now = Utc::now();
+    let time_left = Some(60_000_000_000_i64);
+    let turn = history.split_terminator(';').count() as i32;
+
+    let game = Game::create(
+        NewGame {
+            nanoid: nanoid::nanoid!(12),
+            current_player_id: if turn % 2 == 0 { white.id } else { black.id },
+            black_id: black.id,
+            finished: false,
+            game_status: if turn > 0 {
+                GameStatus::InProgress.to_string()
+            } else {
+                GameStatus::NotStarted.to_string()
+            },
+            game_type: GameType::MLP.to_string(),
+            history: history.to_string(),
+            game_control_history: String::new(),
+            rated: true,
+            tournament_queen_rule: false,
+            turn,
+            white_id: white.id,
+            white_rating: None,
+            black_rating: None,
+            white_rating_change: None,
+            black_rating_change: None,
+            created_at: now,
+            updated_at: now,
+            time_mode: TimeMode::RealTime.to_string(),
+            time_base: Some(60),
+            time_increment: Some(0),
+            last_interaction: if turn > 0 { Some(now) } else { None },
+            black_time_left: time_left,
+            white_time_left: time_left,
+            speed: GameSpeed::Bullet.to_string(),
+            hashes: Vec::new(),
+            conclusion: Conclusion::Unknown.to_string(),
+            tournament_id: None,
+            tournament_game_result: TournamentGameResult::Unknown.to_string(),
+            game_start: GameStart::Moves.to_string(),
+            move_times: Vec::new(),
+        },
+        conn,
+    )
+    .await
+    .unwrap();
+
+    (game, white, black)
+}


### PR DESCRIPTION
This PR:
1. adds a script to backfill hashes on the games table via cd db; cargo run --bin backfill_hashes;
2. a new table: game_hashes which is a lookup table which can be used to answer questions like: show me the top X games where this hash appeared (and more complex queries in the future)
