### PR TITLE
Add bot challenge deletion endpoints

### DIFF
--- a/apis/src/api/v1/bot/challenges.rs
+++ b/apis/src/api/v1/bot/challenges.rs
@@ -1,13 +1,18 @@
 use crate::{
     api::v1::{
         auth::Auth,
-        messages::send::{send_challenge_creation_message, send_challenge_messages},
+        messages::send::{
+            send_challenge_creation_message,
+            send_challenge_messages,
+            send_challenge_removed_messages,
+        },
     },
     notifications::{notify, time_control_label, Event},
     responses::{ChallengeResponse, GameResponse},
     websocket::WsHub,
 };
 use actix_web::{
+    delete,
     get,
     post,
     web::{Data, Json, Path},
@@ -25,6 +30,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use shared_types::{
     ChallengeDetails,
+    ChallengeError,
     ChallengeId,
     ChallengeVisibility,
     CorrespondenceMode,
@@ -187,6 +193,61 @@ pub async fn api_accept_challenge(
     }
 }
 
+#[delete("/api/v1/bot/challenge/{nanoid}")]
+pub async fn api_delete_challenge(
+    nanoid: Path<ChallengeId>,
+    Auth(bot): Auth,
+    pool: Data<DbPool>,
+    hub: Data<Arc<WsHub>>,
+) -> HttpResponse {
+    let nanoid = nanoid.into_inner();
+    match delete_challenge(nanoid, bot.clone(), pool, hub).await {
+        Ok(challenge_id) => HttpResponse::Ok().json(json!({
+          "success": true,
+          "data": {
+            "bot": bot.email,
+            "bot_username": bot.username,
+            "challenge_id": challenge_id,
+          }
+        })),
+        Err(e) => HttpResponse::Ok().json(json!({
+          "success": false,
+          "data": {
+            "error": e.to_string(),
+          }
+        })),
+    }
+}
+
+#[delete("/api/v1/bot/challenges/")]
+pub async fn api_delete_challenges(
+    Auth(bot): Auth,
+    pool: Data<DbPool>,
+    hub: Data<Arc<WsHub>>,
+) -> HttpResponse {
+    match delete_own_challenges(bot.id, pool, hub).await {
+        Ok(result) => {
+            let count = result.challenge_ids.len();
+            HttpResponse::Ok().json(json!({
+              "success": true,
+              "data": {
+                "bot": bot.email,
+                "bot_username": bot.username,
+                "challenge_ids": result.challenge_ids,
+                "count": count,
+                "failures": result.failures,
+              }
+            }))
+        }
+        Err(e) => HttpResponse::Ok().json(json!({
+          "success": false,
+          "data": {
+            "error": e.to_string(),
+          }
+        })),
+    }
+}
+
 #[post("/api/v1/bot/challenges/")]
 pub async fn api_create_challenge(
     Json(req): Json<BotChallengeRequest>,
@@ -256,6 +317,82 @@ async fn create_challenge(
     send_challenge_creation_message(hub, &challenge_response, &req.visibility, opponent_id).await?;
 
     Ok(challenge_response)
+}
+
+#[derive(Serialize)]
+struct ChallengeDeleteFailure {
+    challenge_id: ChallengeId,
+    error: String,
+}
+
+struct DeleteChallengesResult {
+    challenge_ids: Vec<ChallengeId>,
+    failures: Vec<ChallengeDeleteFailure>,
+}
+
+async fn delete_challenge(
+    id: ChallengeId,
+    bot: User,
+    pool: Data<DbPool>,
+    hub: Data<Arc<WsHub>>,
+) -> Result<ChallengeId> {
+    let mut conn = get_conn(&pool).await?;
+    let challenge = Challenge::find_by_challenge_id(&id, &mut conn).await?;
+
+    if !bot.admin && challenge.challenger_id != bot.id && challenge.opponent_id != Some(bot.id) {
+        return Err(ChallengeError::NotUserChallenge.into());
+    }
+
+    let response = ChallengeResponse::from_model(&challenge, &mut conn).await?;
+    challenge.delete(&mut conn).await?;
+    drop(conn);
+
+    send_challenge_removed_messages(hub, vec![response]).await;
+    Ok(id)
+}
+
+async fn delete_own_challenges(
+    bot_id: Uuid,
+    pool: Data<DbPool>,
+    hub: Data<Arc<WsHub>>,
+) -> Result<DeleteChallengesResult> {
+    let mut conn = get_conn(&pool).await?;
+    let challenges = Challenge::get_own(bot_id, &mut conn).await?;
+    let mut challenge_ids = Vec::with_capacity(challenges.len());
+    let mut failures = Vec::new();
+    let mut deleted = Vec::with_capacity(challenges.len());
+
+    for challenge in challenges {
+        let challenge_id = ChallengeId(challenge.nanoid.clone());
+        let response = match ChallengeResponse::from_model(&challenge, &mut conn).await {
+            Ok(response) => response,
+            Err(error) => {
+                failures.push(ChallengeDeleteFailure {
+                    challenge_id,
+                    error: error.to_string(),
+                });
+                continue;
+            }
+        };
+
+        match challenge.delete(&mut conn).await {
+            Ok(()) => {
+                challenge_ids.push(challenge_id);
+                deleted.push(response);
+            }
+            Err(error) => failures.push(ChallengeDeleteFailure {
+                challenge_id,
+                error: error.to_string(),
+            }),
+        }
+    }
+    drop(conn);
+
+    send_challenge_removed_messages(hub, deleted).await;
+    Ok(DeleteChallengesResult {
+        challenge_ids,
+        failures,
+    })
 }
 
 async fn accept_challenge(

--- a/apis/src/api/v1/messages/send.rs
+++ b/apis/src/api/v1/messages/send.rs
@@ -227,6 +227,52 @@ pub async fn send_challenge_creation_message(
     Ok(())
 }
 
+pub async fn send_challenge_removed_messages(
+    hub: Data<Arc<WsHub>>,
+    challenges: Vec<ChallengeResponse>,
+) {
+    let mut messages = Vec::new();
+
+    for challenge in challenges {
+        match challenge.visibility {
+            ChallengeVisibility::Public => {
+                messages.push(InternalServerMessage {
+                    destination: MessageDestination::Global,
+                    message: ServerMessage::Challenge(ChallengeUpdate::Removed(
+                        challenge.challenge_id,
+                    )),
+                });
+            }
+            ChallengeVisibility::Private => {
+                messages.push(InternalServerMessage {
+                    destination: MessageDestination::User(challenge.challenger.uid),
+                    message: ServerMessage::Challenge(ChallengeUpdate::Removed(
+                        challenge.challenge_id,
+                    )),
+                });
+            }
+            ChallengeVisibility::Direct => {
+                if let Some(opponent) = challenge.opponent {
+                    messages.push(InternalServerMessage {
+                        destination: MessageDestination::User(opponent.uid),
+                        message: ServerMessage::Challenge(ChallengeUpdate::Removed(
+                            challenge.challenge_id.clone(),
+                        )),
+                    });
+                    messages.push(InternalServerMessage {
+                        destination: MessageDestination::User(challenge.challenger.uid),
+                        message: ServerMessage::Challenge(ChallengeUpdate::Removed(
+                            challenge.challenge_id,
+                        )),
+                    });
+                }
+            }
+        }
+    }
+
+    send_messages_batch(hub.as_ref(), messages).await;
+}
+
 pub async fn send_control_messages(
     hub: Data<Arc<WsHub>>,
     game: &Game,

--- a/apis/src/main.rs
+++ b/apis/src/main.rs
@@ -14,7 +14,7 @@ use apis::websocket::{self, WebsocketData};
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     use websocket::{start_connection, WsHub};
-    use api::v1::bot::{games::{api_get_game, api_get_ongoing_games, api_get_pending_games}, play::{api_control, api_play}, challenges::{api_accept_challenge, api_create_challenge, api_get_challenges}};
+    use api::v1::bot::{games::{api_get_game, api_get_ongoing_games, api_get_pending_games}, play::{api_control, api_play}, challenges::{api_accept_challenge, api_create_challenge, api_delete_challenge, api_delete_challenges, api_get_challenges}};
     use api::v1::auth::get_token_handler::get_token;
     use api::v1::auth::get_identity_handler::get_identity;
     use api::v1::auth::jwt_secret::JwtSecret;
@@ -171,6 +171,8 @@ async fn main() -> std::io::Result<()> {
             .service(api_get_user)
             .service(api_get_challenges)
             .service(api_accept_challenge)
+            .service(api_delete_challenge)
+            .service(api_delete_challenges)
             .service(api_create_challenge)
 
             // .leptos_routes(leptos_options.to_owned(), routes.to_owned(), App)


### PR DESCRIPTION
# Bot challenge deletion API

Both endpoints require a bot bearer token:

```http
Authorization: Bearer <token>
```

## Remove one challenge

```http
DELETE /api/v1/bot/challenge/{nanoid}
```

The challenger, addressed opponent, or an admin bot may remove the challenge.

```json
{
  "success": true,
  "data": {
    "bot": "bot@example.com",
    "bot_username": "ExampleBot",
    "challenge_id": "challenge-nanoid"
  }
}
```

## Remove all challenges created by the bot

```http
DELETE /api/v1/bot/challenges/
```

This is a best-effort operation. Incoming direct challenges are not removed.

```json
{
  "success": true,
  "data": {
    "bot": "bot@example.com",
    "bot_username": "ExampleBot",
    "challenge_ids": ["first-nanoid", "second-nanoid"],
    "count": 2,
    "failures": []
  }
}
```

Individual bulk failures are returned as objects containing `challenge_id` and
`error`. Handled errors use the existing HTTP 200 bot API error envelope:

```json
{
  "success": false,
  "data": { "error": "message" }
}
```

Successful removals also publish the existing WebSocket challenge-removal
updates to affected clients.
