### PR TITLE
Fix opening explorer notation to match current board orientation

### DIFF
--- a/apis/src/components/organisms/analysis/opening_explorer.rs
+++ b/apis/src/components/organisms/analysis/opening_explorer.rs
@@ -23,10 +23,14 @@ use shared_types::{
 };
 use std::{collections::HashMap, str::FromStr};
 
-/// Map every legal move from `state` to the canonical hash of the resulting position. This lets
-/// the client translate a server suggestion (keyed by the resulting hash) back into a concrete
-/// local move, independent of the rotational frame the suggestion's notation was authored in.
-fn local_moves(state: &State) -> HashMap<u64, (Piece, Position)> {
+/// Map every legal move from `state` to the canonical hash of the resulting position, together
+/// with the move's notation regenerated fresh against the current (correctly-oriented) board.
+/// This lets the client translate a server suggestion (keyed by the resulting hash) back into a
+/// concrete local move and label, independent of the rotational frame the suggestion's notation
+/// was authored in — the server's `piece`/`position` strings are only a display label from
+/// whichever orientation the underlying game happened to be recorded in, and are not
+/// transformed to match the current board.
+fn local_moves(state: &State) -> HashMap<u64, (Piece, Position, String)> {
     let mut map = HashMap::new();
     let base_len = state.hashes.len();
     let color = state.turn_color;
@@ -36,7 +40,8 @@ fn local_moves(state: &State) -> HashMap<u64, (Piece, Position)> {
             if s.play_turn_from_position(piece, target).is_ok() {
                 // Use the move hash, not the auto-pass hash that may follow it.
                 if let Some(&h) = s.hashes.get(base_len) {
-                    map.entry(h).or_insert((piece, target));
+                    let label = notation_label(&s, piece, target);
+                    map.entry(h).or_insert((piece, target, label));
                 }
             }
         }
@@ -49,13 +54,25 @@ fn local_moves(state: &State) -> HashMap<u64, (Piece, Position)> {
                 let mut s = state.clone();
                 if s.play_turn_from_position(piece, target).is_ok() {
                     if let Some(&h) = s.hashes.get(base_len) {
-                        map.entry(h).or_insert((piece, target));
+                        let label = notation_label(&s, piece, target);
+                        map.entry(h).or_insert((piece, target, label));
                     }
                 }
             }
         }
     }
     map
+}
+
+/// Render a move's notation as `"<piece> <pos>"`, matching `History`'s own display join
+/// (`piece pos`), from a board state where the move has already been played.
+fn notation_label(state_after_move: &State, piece: Piece, target: Position) -> String {
+    let (piece_str, pos_str) = state_after_move.move_notation(piece, target);
+    if pos_str.is_empty() {
+        piece_str
+    } else {
+        format!("{piece_str} {pos_str}")
+    }
 }
 
 fn pct(part: i64, total: i64) -> f64 {
@@ -241,7 +258,7 @@ pub fn OpeningExplorer(
 fn render_response(
     response: ExplorerResponse,
     handlers: RowHandlers,
-    local: &HashMap<u64, (Piece, Position)>,
+    local: &HashMap<u64, (Piece, Position, String)>,
     search_href: Option<String>,
 ) -> impl IntoView {
     let header = response.position_total;
@@ -258,7 +275,7 @@ fn render_response(
         .into_iter()
         .filter(|m| m.total > 0)
         .map(|m| {
-            let local_move = local.get(&(m.next_hash as u64)).copied();
+            let local_move = local.get(&(m.next_hash as u64)).cloned();
             move_row(m, local_move, handlers)
         })
         .collect_view();
@@ -407,33 +424,42 @@ fn top_game_row(g: crate::responses::GameResponse) -> impl IntoView {
 
 fn move_row(
     m: ExplorerMove,
-    local_move: Option<(Piece, Position)>,
+    local_move: Option<(Piece, Position, String)>,
     handlers: RowHandlers,
 ) -> impl IntoView {
-    let label = if m.position.is_empty() {
-        m.piece.clone()
-    } else {
-        format!("{} {}", m.piece, m.position)
-    };
+    // Prefer the label regenerated from the local, correctly-oriented board (matches the move
+    // that gets played); fall back to the server's representative label — which may have been
+    // authored in a different board orientation — only when we can't map the suggestion onto a
+    // local move at all.
+    let label = local_move
+        .as_ref()
+        .map(|(_, _, label)| label.clone())
+        .unwrap_or_else(|| {
+            if m.position.is_empty() {
+                m.piece.clone()
+            } else {
+                format!("{} {}", m.piece, m.position)
+            }
+        });
     let total = m.total;
     let (white, draws, black) = (m.white_wins, m.draws, m.black_wins);
     let mover_wins = if handlers.white_to_move { white } else { black };
     let score = pct(mover_wins, total); // win share; draws shown separately in the bar
-                                        // Prefer the locally-derived piece (matches the move that gets played); fall back to the
-                                        // server's representative label when we can't map the suggestion onto a local move.
     let icon_piece = local_move
-        .map(|(piece, _)| piece)
+        .as_ref()
+        .map(|(piece, _, _)| *piece)
         .or_else(|| Piece::from_str(&m.piece).ok());
+    let play_move = local_move.as_ref().map(|(piece, pos, _)| (*piece, *pos));
     view! {
         <tr
             class="border-t transition-colors cursor-pointer border-black/10 dark:border-white/10 dark:hover:bg-pillbug-teal/15 hover:bg-blue-light/70"
             on:click=move |_| {
-                if let Some(mv) = local_move {
+                if let Some(mv) = play_move {
                     handlers.play.run(mv);
                 }
             }
             on:mouseenter=move |_| {
-                if let Some(mv) = local_move {
+                if let Some(mv) = play_move {
                     handlers.preview.run(mv);
                 }
             }

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -233,20 +233,25 @@ impl State {
     }
 
     fn update_history(&mut self, piece: Piece, target_position: Position) {
+        let (piece_str, pos_str) = self.move_notation(piece, target_position);
+        self.history.record_move(piece_str, pos_str);
+    }
+
+    /// Compute the history notation for playing `piece` to `target_position` from the current
+    /// board, without mutating any state. Used both by `update_history` and by callers (e.g. the
+    /// opening explorer) that need notation for a hypothetical move against a board they hold,
+    /// independent of whatever orientation that move's stored/canonical notation was authored in.
+    pub fn move_notation(&self, piece: Piece, target_position: Position) -> (String, String) {
         if self.board.positions.into_iter().flatten().count() == 1 {
-            self.history.record_move(piece.to_string(), "".to_string());
-            return;
+            return (piece.to_string(), "".to_string());
         }
         if let Some(destination_piece) = self.board.under_piece(target_position) {
-            self.history
-                .record_move(piece.to_string(), destination_piece.to_string());
-            return;
+            return (piece.to_string(), destination_piece.to_string());
         }
         if let Some((neighbor_piece, neighbor_pos)) = self.board.get_neighbor(target_position) {
             let dir = neighbor_pos.direction(target_position);
             let pos = dir.to_history_string(neighbor_piece.to_string());
-            self.history.record_move(piece.to_string(), pos);
-            return;
+            return (piece.to_string(), pos);
         }
         unreachable!()
     }
@@ -467,5 +472,28 @@ mod tests {
             h.insert(s.board.hasher.hash);
         }
         assert_eq!(h.len(), 8);
+    }
+
+    /// `move_notation` must reproduce exactly what `update_history` (via `play_turn_from_position`)
+    /// records, since the opening explorer relies on it to regenerate notation for a hypothetical
+    /// move without mutating the state it's evaluating.
+    #[test]
+    fn move_notation_matches_recorded_history() {
+        let mut s = State::new(GameType::Base, false);
+        s.play_turn_from_history("wA1", ".").unwrap();
+        s.play_turn_from_history("bA1", "wA1-").unwrap();
+
+        // A fresh spawn: exercises the `get_neighbor`/direction-glyph branch.
+        let color = s.turn_color;
+        let piece: Piece = "wA2".parse().unwrap();
+        let target = s.board.spawnable_positions(color).next().unwrap();
+
+        let expected = s.move_notation(piece, target);
+
+        let mut played = s.clone();
+        played.play_turn_from_position(piece, target).unwrap();
+        let recorded = played.history.moves.last().cloned().unwrap();
+
+        assert_eq!(expected, recorded);
     }
 }


### PR DESCRIPTION
The explorer showed a suggested move notation exactly as the server stored it, even though that notation was recorded under a different game's board orientation. Notation is now regenerated locally from the simulated move against the viewer's own board instead.

Tested on local instance.