### PR TITLE
Stops the board jumping when recenter shifts raw coordinates

### DIFF
--- a/apis/src/common/mod.rs
+++ b/apis/src/common/mod.rs
@@ -62,7 +62,7 @@ pub use server_result::{
     UserStatus,
     UserUpdate,
 };
-pub use svg_pos::{position_from_svg, SvgPos};
+pub use svg_pos::{pixel_delta_for_shift, position_from_svg, SvgPos};
 pub use time_signals::{TimeParams, TimeParamsStoreFields};
 pub use tournament_action::{TournamentAction, TournamentResponseDepth};
 pub use ui_utils::{render_text_prop, with_class};

--- a/apis/src/common/svg_pos.rs
+++ b/apis/src/common/svg_pos.rs
@@ -60,6 +60,16 @@ pub fn hex_height() -> f32 {
     2.0 * HEX_SIZE
 }
 
+/// Pixel translation `center_for_level` produces for a raw `(dq, dr)` coordinate shift, at any
+/// starting position. Deliberately bypasses `Position::new` (which wraps into `0..BOARD_SIZE` and
+/// would corrupt a negative or out-of-range delta) - lets the camera cancel a `Board::recenter`
+/// shift without needing a real, addressable `Position` for the delta itself.
+pub fn pixel_delta_for_shift(dq: i32, dr: i32) -> (f32, f32) {
+    let w = hex_width();
+    let h = hex_height();
+    ((dq as f32 + dr as f32 / 2.0) * w, dr as f32 * 0.75 * h)
+}
+
 /// Inverse of `center` at level 0 (screen point → hex), for click hit-testing.
 /// Mirrors `center`'s row parity and truncating `r / 2` so it round-trips; stack
 /// offsets only apply above level 0, so `straight` doesn't matter here.

--- a/apis/src/components/organisms/board.rs
+++ b/apis/src/components/organisms/board.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{position_from_svg, SvgPos, TileDesign},
+    common::{pixel_delta_for_shift, position_from_svg, SvgPos, TileDesign},
     components::{
         layouts::base_layout::OrientationSignal,
         molecules::{
@@ -358,6 +358,30 @@ pub fn Board(interaction: HivegroundInteraction, history_board: Memo<HiveBoard>)
                 let rect = div.get_bounding_client_rect();
                 update_viewbox_size(rect.width() as f32, rect.height() as f32, false);
             }
+        },
+        false,
+    );
+
+    // `Board::recenter` (engine) periodically re-bases every piece's raw coordinates to keep
+    // them inside the fixed-size storage window. Raw coordinates feed the renderer directly, so
+    // left uncompensated that reads as the whole board jumping when stepping across the ply
+    // where it happened. Since the shift is a uniform translation, panning the camera by the
+    // same pixel delta (in the opposite direction) cancels it exactly, with no need to touch any
+    // `Position` used for hit-testing or move submission.
+    Effect::watch(
+        move || history_board.with(|board| board.recenter_shift),
+        move |shift, prev_shift, _| {
+            let Some(prev_shift) = prev_shift else {
+                return;
+            };
+            if shift == prev_shift {
+                return;
+            }
+            let (dx, dy) = pixel_delta_for_shift(shift.0 - prev_shift.0, shift.1 - prev_shift.1);
+            viewbox_signal.update(|vb| {
+                vb.x_transform -= dx;
+                vb.y_transform -= dy;
+            });
         },
         false,
     );

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -125,6 +125,10 @@ pub struct Board {
     pinned: [bool; 48],
     // number of pieces present on the board
     pub played: usize,
+    /// Net (dq, dr) applied to raw coordinates by every `recenter` call so far. Not part of the
+    /// hive's identity - the renderer uses it to keep the on-screen board from jumping when
+    /// storage-driven recentering moves everyone's raw `Position`.
+    pub recenter_shift: (i32, i32),
 }
 
 /// Storage size is not part of the hive; derived fields follow from the compared ones.
@@ -168,6 +172,7 @@ impl Board {
             positions: [None; 48],
             pinned: [false; 48],
             played: 0,
+            recenter_shift: (0, 0),
         }
     }
 
@@ -258,6 +263,13 @@ impl Board {
             self.last_move.1.map(translate),
         );
         centered.stunned = self.stunned;
+        // Not itself wrapped: a hive that doesn't straddle the seam (the only case this single
+        // delta can compensate for) translates uniformly, so `q_start - q_origin` is the same
+        // for every piece regardless of the `rem_euclid` each individual `translate` applies.
+        centered.recenter_shift = (
+            self.recenter_shift.0 + (q_start - q_origin),
+            self.recenter_shift.1 + (r_start - r_origin),
+        );
         *self = centered;
     }
 
@@ -1522,6 +1534,63 @@ mod tests {
         board.recenter();
         assert_eq!(board.storage_cells(), 256);
         assert!(!board.needs_recentering());
+    }
+
+    /// The renderer cancels a recenter jump by panning the camera the same amount it shifted
+    /// raw coordinates, so the accumulated total - not just the latest call - has to be right.
+    #[test]
+    fn recenter_shift_accumulates_across_multiple_recenters() {
+        let mut board = Board::new();
+        let anchor: Piece = "wQ".parse().expect("test piece");
+        board.insert(Position::new(9, 16), anchor, true);
+        board.insert(
+            Position::new(10, 16),
+            "bQ".parse().expect("test piece"),
+            true,
+        );
+        assert_eq!(board.recenter_shift, (0, 0));
+
+        let before_first = board.position_of_piece(anchor).expect("just inserted");
+        board.recenter();
+        let after_first = board.position_of_piece(anchor).expect("still on the board");
+        assert_eq!(
+            after_first,
+            Position::new(
+                before_first.q + board.recenter_shift.0,
+                before_first.r + board.recenter_shift.1
+            ),
+            "the piece should have moved by exactly the reported shift"
+        );
+        let shift_after_first = board.recenter_shift;
+        assert_ne!(shift_after_first, (0, 0), "the hive was off-centre already");
+
+        // Skew the bounding box so a second `recenter` picks a different target and has to
+        // apply a further, non-zero translation on top of the first.
+        for (offset, piece) in ["wA1", "bA1", "wA2", "bA2", "wG1", "bG1", "wG2", "bG2"]
+            .into_iter()
+            .enumerate()
+        {
+            board.insert(
+                Position::new(21 - offset as i32, 16),
+                piece.parse().expect("test piece"),
+                true,
+            );
+        }
+        let before_second = board.position_of_piece(anchor).expect("still on the board");
+        board.recenter();
+        let after_second = board.position_of_piece(anchor).expect("still on the board");
+        let applied_second = (
+            after_second.q - before_second.q,
+            after_second.r - before_second.r,
+        );
+        assert_eq!(
+            board.recenter_shift,
+            (
+                shift_after_first.0 + applied_second.0,
+                shift_after_first.1 + applied_second.1
+            ),
+            "the second recenter should add to, not replace, the first shift"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Puts the donut on a diet (#806) added Board::recenter(), which periodically translates every piece's raw coordinates to keep them inside the fixed-size storage window. The renderer draws raw coordinates directly and the camera was never adjusted to compensate, so any recenter reads as the whole board panning - reproducible at https://hivegame.com/game/nOxgGLxkSvqw?move=32 by stepping forward one move. Should now be fixed: the camera pans by the exact opposite pixel delta whenever the displayed board's accumulated recenter shift changes, so pieces, overlays, and annotations all land back where they were without touching hit-testing or move submission.